### PR TITLE
updating the host fields with authority

### DIFF
--- a/callouts/python/extproc/example/basic_callout_server.py
+++ b/callouts/python/extproc/example/basic_callout_server.py
@@ -37,7 +37,7 @@ class BasicCalloutServer(CalloutServer):
     This example contains a few of the possible modifications that can be
     applied to a request header callout:
     
-    * A change to the ':host' and ':path' headers.
+    * A change to the ':authority' and ':path' headers.
     * Adding the header 'header-request' with the value of 'request'.
     * Removal of a header 'foo'.
     * Clearing of the route cache.
@@ -47,7 +47,7 @@ class BasicCalloutServer(CalloutServer):
     return add_header_mutation(
         add=[
             # Change the host to 'service-extensions.com'.
-            (':host', 'service-extensions.com'),
+            (':authority', 'service-extensions.com'),
             # Change the destination path to '/'.
             (':path', '/'),
             ('header-request', 'request')

--- a/callouts/python/extproc/example/normalize_header/service_callout_example.py
+++ b/callouts/python/extproc/example/normalize_header/service_callout_example.py
@@ -49,7 +49,7 @@ class CalloutServerExample(callout_server.CalloutServer):
 
     host_value = next((header.raw_value.decode('utf-8')
                        for header in headers.headers.headers
-                       if header.key == ':host'), None)
+                       if header.key == ':authority'), None)
 
     header_mutation = service_pb2.HeadersResponse()
 

--- a/callouts/python/extproc/tests/basic_grpc_test.py
+++ b/callouts/python/extproc/tests/basic_grpc_test.py
@@ -176,7 +176,7 @@ class TestBasicServer(object):
       value = make_request(stub, request_headers=headers)
       assert value.HasField('request_headers')
       assert value.request_headers == add_header_mutation(
-          add=[(':host', 'service-extensions.com'), (':path', '/'),
+          add=[(':authority', 'service-extensions.com'), (':path', '/'),
                ('header-request', 'request')],
           clear_route_cache=True,
           remove=['foo'])

--- a/callouts/python/extproc/tests/ext_proc_client_test.py
+++ b/callouts/python/extproc/tests/ext_proc_client_test.py
@@ -77,7 +77,7 @@ def test_basic_callouts(server: CalloutServerTest) -> None:
   response = make_request(ProcessingRequest(request_headers=headers), addr)
   assert response.request_headers == add_header_mutation(
     add=[
-      (':host', 'service-extensions.com'),
+      (':authority', 'service-extensions.com'),
       (':path', '/'),
       ('header-request', 'request'),
     ],

--- a/callouts/python/extproc/tests/normalize_header_test.py
+++ b/callouts/python/extproc/tests/normalize_header_test.py
@@ -42,7 +42,7 @@ def test_normalize_header(server: CalloutServerTest) -> None:
 
     def make_test_headers(host_value: bytes) -> service_pb2.HttpHeaders:
       return service_pb2.HttpHeaders(headers=HeaderMap(
-          headers=[HeaderValue(key=":host", raw_value=host_value)]),
+          headers=[HeaderValue(key=":authority", raw_value=host_value)]),
                                      end_of_stream=False)
 
     mobile_headers = make_test_headers(b"m.example.com")


### PR DESCRIPTION
Envoy passes the host header with the key `authority` instead of `host`. Several of the sample Python files used the incorrect `host` key instead of `authority`.
This pull request fixes a number of these errors.