### PR TITLE
feat: create a C++ sample plugin for overwriting error codes from 5XX  to 4XX classes.

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -63,6 +63,8 @@ for your own plugin. Extend them to fit your particular use case.
 *   [Normalize a HTTP header on request](samples/normalize_header): Creates a new
     HTTP header (client-device-type) to shard requests based on device according
     to the existence of HTTP Client Hints or User-Agent header values.
+*   [Overwrite origin response error code](samples/overwrite_errcode): Overwrites
+    error code served from origin from 5xx error to 4xx error class.
 
 # Samples tests
 

--- a/plugins/samples/overwrite_errcode/BUILD
+++ b/plugins/samples/overwrite_errcode/BUILD
@@ -1,0 +1,20 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_cpp.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/overwrite_errcode/plugin.cc
+++ b/plugins/samples/overwrite_errcode/plugin.cc
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_overwrite_errcode]
+#include "absl/strings/match.h"
+#include "proxy_wasm_intrinsics.h"
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onResponseHeaders(uint32_t headers,
+                                        bool end_of_stream) override {
+    const auto status = getResponseHeader(":status");
+    // Replaces the error code from 5XX to 4XX
+    if (status && absl::StartsWithIgnoreCase(status->view(), "5")) {
+      replaceResponseHeader(":status", status->toString().replace(0, 1, "4"));
+    }
+
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
+// [END serviceextensions_plugin_overwrite_errcode]

--- a/plugins/samples/overwrite_errcode/plugin.cc
+++ b/plugins/samples/overwrite_errcode/plugin.cc
@@ -36,7 +36,7 @@ class MyHttpContext : public Context {
   }
 
  private:
-  int mapResponseCode(int response_code) {
+  static int mapResponseCode(int response_code) {
     // Example: remap all 5xx responses to 404.
     return (response_code / 100 == 5) ? 404 : response_code;
   }

--- a/plugins/samples/overwrite_errcode/tests.textpb
+++ b/plugins/samples/overwrite_errcode/tests.textpb
@@ -1,10 +1,50 @@
-# Given a 5XX return code, expect change to 4XX
+# Given a 500 return code, expect change to 400
 test {
-  name: "With5XXStatusCodeChangeTo4XX"
+  name: "With500StatusCodeChangeTo400"
   response_headers {
-    input { header { key: ":status" value: "510" } }
+    input { header { key: ":status" value: "500" } }
     result { 
-      has_header { key: ":status" value: "410" }
+      has_header { key: ":status" value: "400" }
+    }
+  }
+}
+# Given a 502 return code, expect change to 400
+test {
+  name: "With502StatusCodeChangeTo400"
+  response_headers {
+    input { header { key: ":status" value: "502" } }
+    result { 
+      has_header { key: ":status" value: "400" }
+    }
+  }
+}
+# Given a 503 return code, expect change to 429
+test {
+  name: "With503StatusCodeChangeTo429"
+  response_headers {
+    input { header { key: ":status" value: "503" } }
+    result { 
+      has_header { key: ":status" value: "429" }
+    }
+  }
+}
+# Given a 504 return code, expect change to 408
+test {
+  name: "With504StatusCodeChangeTo408"
+  response_headers {
+    input { header { key: ":status" value: "504" } }
+    result { 
+      has_header { key: ":status" value: "408" }
+    }
+  }
+}
+# Given a 599 return code, expect change to 404
+test {
+  name: "With599StatusCodeChangeTo404"
+  response_headers {
+    input { header { key: ":status" value: "599" } }
+    result { 
+      has_header { key: ":status" value: "404" }
     }
   }
 }

--- a/plugins/samples/overwrite_errcode/tests.textpb
+++ b/plugins/samples/overwrite_errcode/tests.textpb
@@ -1,48 +1,18 @@
-# Given a 500 return code, expect change to 400
+# Given a 500 return code, expect change to 404
 test {
-  name: "With500StatusCodeChangeTo400"
+  name: "With500StatusCodeChangeTo404"
   response_headers {
     input { header { key: ":status" value: "500" } }
     result { 
-      has_header { key: ":status" value: "400" }
+      has_header { key: ":status" value: "404" }
     }
   }
 }
-# Given a 502 return code, expect change to 400
+# Given a 502 return code, expect change to 404
 test {
-  name: "With502StatusCodeChangeTo400"
+  name: "With502StatusCodeChangeTo404"
   response_headers {
     input { header { key: ":status" value: "502" } }
-    result { 
-      has_header { key: ":status" value: "400" }
-    }
-  }
-}
-# Given a 503 return code, expect change to 429
-test {
-  name: "With503StatusCodeChangeTo429"
-  response_headers {
-    input { header { key: ":status" value: "503" } }
-    result { 
-      has_header { key: ":status" value: "429" }
-    }
-  }
-}
-# Given a 504 return code, expect change to 408
-test {
-  name: "With504StatusCodeChangeTo408"
-  response_headers {
-    input { header { key: ":status" value: "504" } }
-    result { 
-      has_header { key: ":status" value: "408" }
-    }
-  }
-}
-# Given a 599 return code, expect change to 404
-test {
-  name: "With599StatusCodeChangeTo404"
-  response_headers {
-    input { header { key: ":status" value: "599" } }
     result { 
       has_header { key: ":status" value: "404" }
     }

--- a/plugins/samples/overwrite_errcode/tests.textpb
+++ b/plugins/samples/overwrite_errcode/tests.textpb
@@ -1,0 +1,20 @@
+# Given a 5XX return code, expect change to 4XX
+test {
+  name: "With5XXStatusCodeChangeTo4XX"
+  response_headers {
+    input { header { key: ":status" value: "510" } }
+    result { 
+      has_header { key: ":status" value: "410" }
+    }
+  }
+}
+# Given a 200 return code, expect no changes
+test {
+  name: "With200StatusCodeNothingChanges"
+  response_headers {
+    input { header { key: ":status" value: "200" } }
+    result { 
+      has_header { key: ":status" value: "200" }
+    }
+  }
+}


### PR DESCRIPTION
This plugin is a create HTTP cookie showcase.

Technically, this is performed by replacing the 5XX error code response to 4XX. 

This examples contains only a C++ version.
