### PR TITLE
chore: change set_cookie and block_request plugins to use absl::Random instead of timestamp to generate IDs

### DIFF
--- a/plugins/samples/block_request/BUILD
+++ b/plugins/samples/block_request/BUILD
@@ -7,6 +7,7 @@ proxy_wasm_plugin_cpp(
     srcs = ["plugin.cc"],
     deps = [
         "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+        "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/plugins/samples/block_request/tests.textpb
+++ b/plugins/samples/block_request/tests.textpb
@@ -1,8 +1,3 @@
-env {
-  log_level: DEBUG  # aka --loglevel
-  log_path: "/dev/stdout"  # aka --logfile
-  time_secs: 123456789  # set clock
-}
 # Referer and Host match, expected allowed request.
 test {
   name: "NoForbiddenReferer"
@@ -24,8 +19,8 @@ test {
     }
     result {
       immediate { http_status: 403 details: "" }
-      body { exact: "Forbidden - Request ID: 123456789000000000" }
-      log { regex: ".+Forbidden - Request ID: 123456789000000000" }
+      body { regex: "Forbidden - Request ID: \\d+" }
+      log { regex: ".+Forbidden - Request ID: \\d+" }
       no_header { key: "my-plugin-allowed"}
     }
   }

--- a/plugins/samples/set_cookie/BUILD
+++ b/plugins/samples/set_cookie/BUILD
@@ -7,6 +7,7 @@ proxy_wasm_plugin_cpp(
     srcs = ["plugin.cc"],
     deps = [
         "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+        "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/plugins/samples/set_cookie/tests.textpb
+++ b/plugins/samples/set_cookie/tests.textpb
@@ -1,6 +1,3 @@
-env {
-  time_secs: 123456789  # set clock
-}
 test {
   name: "WihSessionIdSetKeepTheSameAndLog"
   request_headers {
@@ -20,8 +17,8 @@ test {
   }
   response_headers {
     result { 
-      has_header { key: "Set-Cookie" value: "my_cookie=123456789000000000; Path=/; HttpOnly" }
-      log { regex: ".+New session ID created for the current request: 123456789000000000" }
+      headers { regex: "Set-Cookie: my_cookie=\\d+; Path=/; HttpOnly" }
+      log { regex: ".+New session ID created for the current request: \\d+" }
     }
   }
 }


### PR DESCRIPTION
Given that now it's possible to use `absl::Random` in plugin examples, thanks to [chore: Update C++ dependencies, enable RE2 plugin by martijneken · Pull Request #124 · GoogleCloudPlatform/service-extensions](https://github.com/GoogleCloudPlatform/service-extensions/pull/124) .   
The `set_cookie` and the `block_request` plugins should be updated to start using it instead of timestamp.