### PR TITLE
feat: adding new c++ sample plugin to check for PII on responses

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -79,7 +79,7 @@ for your own plugin. Extend them to fit your particular use case.
 *   [Validate client JWT for authorization](samples/jwt_auth): Ensures user
     authentication by verifying an RS256-signed JWT token in the query string
     and subsequently removing it.
-    [Check for PII on response](samples/check_pii): Checks the response http headers,
+*   [Check for PII on response](samples/check_pii): Checks the response http headers,
     and the response body for the presence of credit card numbers. If found, the
     initial numbers will be masked.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -79,6 +79,9 @@ for your own plugin. Extend them to fit your particular use case.
 *   [Validate client JWT for authorization](samples/jwt_auth): Ensures user
     authentication by verifying an RS256-signed JWT token in the query string
     and subsequently removing it.
+    [Check for PII on response](samples/check_pii): Checks the response http headers,
+    and the response body for the presence of credit card numbers. If found, the
+    initial numbers will be masked.
 
 # Samples tests
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -79,8 +79,8 @@ for your own plugin. Extend them to fit your particular use case.
 *   [Validate client JWT for authorization](samples/jwt_auth): Ensures user
     authentication by verifying an RS256-signed JWT token in the query string
     and subsequently removing it.
-*   [Check for PII on response](samples/check_pii): Checks the response http headers,
-    and the response body for the presence of credit card numbers. If found, the
+*   [Check for PII on response](samples/check_pii): Checks the response HTTP
+    headers and body for the presence of credit card numbers. If found, the
     initial numbers will be masked.
 
 # Samples tests

--- a/plugins/samples/check_pii/BUILD
+++ b/plugins/samples/check_pii/BUILD
@@ -1,0 +1,20 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//contrib:contrib_lib",
+        "@com_google_re2//:re2",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_cpp.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/check_pii/plugin.cc
+++ b/plugins/samples/check_pii/plugin.cc
@@ -23,7 +23,8 @@ class MyRootContext : public RootContext {
 
   bool onConfigure(size_t) override {
     // Credit card numbers in a 19 character hyphenated format.
-    // Compile the regex expression at plugin setup time.
+    // Compile the regex expression at plugin setup time, so that this expensive
+    // operation is only performed once, and not repeated with each request.
     card_match.emplace("\\d{4}-\\d{4}-\\d{4}-(\\d{4})");
     return card_match->ok();
   }
@@ -33,6 +34,9 @@ class MyRootContext : public RootContext {
 
 // Checks the response http headers, and the response body for the presence of
 // credit card numbers. Mask the initial numbers case found.
+// Note that for illustrative purposes, this example is kept simple and does not
+// handle the case of credit card numbers that are split across multiple
+// onResponseBody() calls.
 class MyHttpContext : public Context {
  public:
   explicit MyHttpContext(uint32_t id, RootContext* root)

--- a/plugins/samples/check_pii/plugin.cc
+++ b/plugins/samples/check_pii/plugin.cc
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_check_pii]
+#include "proxy_wasm_intrinsics.h"
+#include "re2/re2.h"
+
+class MyRootContext : public RootContext {
+ public:
+  explicit MyRootContext(uint32_t id, std::string_view root_id)
+      : RootContext(id, root_id) {}
+
+  bool onConfigure(size_t) override {
+    // Credit card numbers in a 19 character hyphenated format.
+    // Compile the regex expression at plugin setup time.
+    card_match.emplace("\\d{4}-\\d{4}-\\d{4}-(\\d{4})");
+    return card_match->ok();
+  }
+
+  std::optional<re2::RE2> card_match;
+};
+
+// Checks the response http headers, and the response body for the presence of
+// credit card numbers. Mask the initial numbers case found.
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root)
+      : Context(id, root), root_(static_cast<MyRootContext*>(root)) {}
+
+  FilterHeadersStatus onResponseHeaders(uint32_t headers,
+                                        bool end_of_stream) override {
+    const auto pii_header = getResponseHeader("google-run-pii-check");
+    if (pii_header && pii_header->view() == "true") {
+      check_body_ = true;
+      const auto result = getResponseHeaderPairs();
+      const auto pairs = result->pairs();
+      for (auto& p : pairs) {
+        std::string header_value = std::string(p.second);  // mutable copy
+        if (maskCardNumbers(header_value)) {
+          replaceResponseHeader(p.first, header_value);
+        }
+      }
+    }
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterDataStatus onResponseBody(size_t body_buffer_length,
+                                  bool end_of_stream) override {
+    if (check_body_) {
+      const auto body = getBufferBytes(WasmBufferType::HttpResponseBody, 0,
+                                       body_buffer_length);
+      std::string body_string = body->toString();  // mutable copy
+      if (maskCardNumbers(body_string)) {
+        setBuffer(WasmBufferType::HttpResponseBody, 0, body_buffer_length,
+                  body_string);
+      }
+    }
+    return FilterDataStatus::Continue;
+  }
+
+ private:
+  const MyRootContext* root_;
+  bool check_body_ = false;
+
+  bool maskCardNumbers(std::string& value) {
+    return re2::RE2::GlobalReplace(&value, *root_->card_match,
+                                   "XXXX-XXXX-XXXX-\\1") > 0;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));
+// [END serviceextensions_plugin_check_pii]

--- a/plugins/samples/check_pii/tests.textpb
+++ b/plugins/samples/check_pii/tests.textpb
@@ -1,0 +1,68 @@
+test {
+  name: "WithRunCheckHeaderOverwriteCardNumberOnResponseHeader"
+  response_headers {
+    input { 
+      header { key: "x-card-number" value: "1234-5678-9123-4567"}
+      header { key: "google-run-pii-check" value: "true"}
+    }
+    result { 
+      has_header { key: "x-card-number" value: "XXXX-XXXX-XXXX-4567" }
+    }
+  }
+}
+test {
+  name: "WithoutRunCheckHeaderKeepTheOriginalHeaders"
+  response_headers {
+    input { 
+      header { key: "x-card-number" value: "1234-5678-9123-4567"}
+      header { key: "google-run-pii-check" value: "false"}
+    }
+    result { 
+      has_header { key: "x-card-number" value: "1234-5678-9123-4567" }
+    }
+  }
+}
+test {
+  name: "WithRunCheckHeaderOverwriteCardNumberOnBody"
+  response_headers {
+    input { 
+      header { key: "google-run-pii-check" value: "true"}
+    }
+  }
+  response_body {
+    input {
+      content: "dsddssds dsdsod dsds dsds dsdssds"
+      "sdsds 1234-5678-9123-4567 sdsds dfdfsdssds"
+      "gfgfgfgf fdfdfdfd 1234-4567-9123-8886 dsds"
+    }
+    result { 
+      body {
+        exact: "dsddssds dsdsod dsds dsds dsdssds"
+        "sdsds XXXX-XXXX-XXXX-4567 sdsds dfdfsdssds"
+        "gfgfgfgf fdfdfdfd XXXX-XXXX-XXXX-8886 dsds"
+      }
+    }
+  }
+}
+test {
+  name: "WithoutRunCheckHeaderKeepTheOriginalBody"
+  response_headers {
+    input { 
+      header { key: "google-run-pii-check" value: "false"}
+    }
+  }
+  response_body {
+    input {
+      content: "dsddssds dsdsod dsds dsds dsdssds"
+      "sdsds 1234-5678-9123-4567 sdsds dfdfsdssds"
+      "gfgfgfgf fdfdfdfd 1234-4567-9123-8886 dsds"
+    }
+    result { 
+      body {
+        exact: "dsddssds dsdsod dsds dsds dsdssds"
+        "sdsds 1234-5678-9123-4567 sdsds dfdfsdssds"
+        "gfgfgfgf fdfdfdfd 1234-4567-9123-8886 dsds"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This plugin is a PII on response check showcase.

Technically, this is performed by checking the response http headers, and the response body for the presence of credit card numbers. If found, the initial numbers will be masked.

This examples contains only a C++ version.