### PR TITLE
fix:Check for incorrect return-type during plugin compilation

### DIFF
--- a/plugins/plugins.bzl
+++ b/plugins/plugins.bzl
@@ -29,8 +29,9 @@ def proxy_wasm_plugin_rust(**kwargs):
         **kwargs
     )
 
-def proxy_wasm_plugin_cpp(**kwargs):
+def proxy_wasm_plugin_cpp(copts = [], **kwargs):
     proxy_wasm_cc_binary(
+        copts = copts + ["-Werror=return-type"],
         **kwargs
     )
 


### PR DESCRIPTION
fix: Check for incorrect return-type during plugin compilation

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
