### PR TITLE
feat: Import sample plugins from the Service Extensions docs

### DIFF
--- a/plugins/samples/docs_first_plugin/BUILD
+++ b/plugins/samples/docs_first_plugin/BUILD
@@ -1,0 +1,26 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "@crate_index//:log",
+        "@crate_index//:proxy-wasm",
+    ],
+)
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_cpp.wasm",
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/docs_first_plugin/plugin.cc
+++ b/plugins/samples/docs_first_plugin/plugin.cc
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_docs_first_plugin]
 #include "proxy_wasm_intrinsics.h"
 
 class MyHttpContext : public Context {
@@ -26,3 +41,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_StaticContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));
+// [END serviceextensions_plugin_docs_first_plugin]

--- a/plugins/samples/docs_first_plugin/plugin.cc
+++ b/plugins/samples/docs_first_plugin/plugin.cc
@@ -1,0 +1,28 @@
+#include "proxy_wasm_intrinsics.h"
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    LOG_INFO("onRequestHeaders: hello from wasm");
+
+    // Route Extension example: host rewrite
+    replaceRequestHeader(":host", "service-extensions.com");
+    replaceRequestHeader(":path", "/");
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterHeadersStatus onResponseHeaders(uint32_t headers,
+                                        bool end_of_stream) override {
+    LOG_INFO("onResponseHeaders: hello from wasm");
+
+    // Traffic Extension example: add response header
+    addResponseHeader("hello", "service-extensions");
+    return FilterHeadersStatus::Continue;
+  }
+};
+
+static RegisterContextFactory register_StaticContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(RootContext));

--- a/plugins/samples/docs_first_plugin/plugin.rs
+++ b/plugins/samples/docs_first_plugin/plugin.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_docs_first_plugin]
 use log::info;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
@@ -29,3 +44,4 @@ impl HttpContext for MyHttpContext {
         return Action::Continue;
     }
 }
+// [END serviceextensions_plugin_docs_first_plugin]

--- a/plugins/samples/docs_first_plugin/plugin.rs
+++ b/plugins/samples/docs_first_plugin/plugin.rs
@@ -1,0 +1,31 @@
+use log::info;
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+proxy_wasm::main! { {
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(MyHttpContext) });
+} }
+
+struct MyHttpContext;
+
+impl Context for MyHttpContext {}
+
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        info!("onRequestHeaders: hello from wasm");
+
+        // Route extension example: host rewrite
+        self.set_http_request_header(":host", Some("service-extensions.com"));
+        self.set_http_request_header(":path", Some("/"));
+        return Action::Continue;
+    }
+
+    fn on_http_response_headers(&mut self, _: usize, _: bool) -> Action {
+        info!("onResponseHeaders: hello from wasm");
+
+        // Traffic extension example: add response header
+        self.add_http_response_header("hello", "service-extensions");
+        return Action::Continue;
+    }
+}

--- a/plugins/samples/docs_first_plugin/tests.textpb
+++ b/plugins/samples/docs_first_plugin/tests.textpb
@@ -1,0 +1,16 @@
+test {
+  name: "Basics"
+  request_headers {
+    result {
+      log { regex: ".*onRequestHeaders: hello from wasm" }
+      has_header { key: ":host" value: "service-extensions.com" }
+      has_header { key: ":path" value: "/" }
+    }
+  }
+  response_headers {
+    result {
+      log { regex: ".*onResponseHeaders: hello from wasm" }
+      has_header { key: "hello" value: "service-extensions" }
+    }
+  }
+}

--- a/plugins/samples/docs_plugin_config/BUILD
+++ b/plugins/samples/docs_plugin_config/BUILD
@@ -1,0 +1,27 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "@crate_index//:log",
+        "@crate_index//:proxy-wasm",
+    ],
+)
+
+proxy_wasm_plugin_cpp(
+    name = "plugin_cpp.wasm",
+    srcs = ["plugin.cc"],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    config = ":tests.config",
+    plugins = [
+        ":plugin_cpp.wasm",
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/docs_plugin_config/plugin.cc
+++ b/plugins/samples/docs_plugin_config/plugin.cc
@@ -1,0 +1,41 @@
+#include <string>
+#include <string_view>
+
+#include "proxy_wasm_intrinsics.h"
+
+class MyRootContext : public RootContext {
+ public:
+  explicit MyRootContext(uint32_t id, std::string_view root_id)
+      : RootContext(id, root_id) {}
+
+  bool onConfigure(size_t config_len) override {
+    secret_ = getBufferBytes(WasmBufferType::PluginConfiguration, 0, config_len)
+                  ->toString();
+    return true;
+  }
+
+  const std::string& secret() const { return secret_; }
+
+ private:
+  std::string secret_;
+};
+
+class MyHttpContext : public Context {
+ public:
+  explicit MyHttpContext(uint32_t id, RootContext* root)
+      : Context(id, root),
+        secret_(static_cast<MyRootContext*>(root)->secret()) {}
+
+  FilterHeadersStatus onRequestHeaders(uint32_t headers,
+                                       bool end_of_stream) override {
+    // Use secret here...
+    LOG_INFO("secret: " + secret_);
+    return FilterHeadersStatus::Continue;
+  }
+
+ private:
+  const std::string& secret_;
+};
+
+static RegisterContextFactory register_MyHttpContext(
+    CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));

--- a/plugins/samples/docs_plugin_config/plugin.cc
+++ b/plugins/samples/docs_plugin_config/plugin.cc
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_docs_plugin_config]
 #include <string>
 #include <string_view>
 
@@ -39,3 +54,4 @@ class MyHttpContext : public Context {
 
 static RegisterContextFactory register_MyHttpContext(
     CONTEXT_FACTORY(MyHttpContext), ROOT_FACTORY(MyRootContext));
+// [END serviceextensions_plugin_docs_plugin_config]

--- a/plugins/samples/docs_plugin_config/plugin.rs
+++ b/plugins/samples/docs_plugin_config/plugin.rs
@@ -1,0 +1,50 @@
+use log::info;
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+use std::rc::Rc;
+
+proxy_wasm::main! { {
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
+        Box::new(MyRootContext { secret: Rc::new("missing".to_string()) })
+    });
+} }
+
+struct MyRootContext {
+    secret: Rc<String>,
+}
+
+impl Context for MyRootContext {}
+
+impl RootContext for MyRootContext {
+    fn on_configure(&mut self, _: usize) -> bool {
+        if let Some(config_bytes) = self.get_plugin_configuration() {
+            self.secret = Rc::new(String::from_utf8(config_bytes).unwrap())
+        }
+        true
+    }
+
+    fn create_http_context(&self, _: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(MyHttpContext {
+            secret: self.secret.clone(), // shallow copy, ref count only
+        }))
+    }
+
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+}
+
+struct MyHttpContext {
+    secret: Rc<String>,
+}
+
+impl Context for MyHttpContext {}
+
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        // Use secret here...
+        info!("secret: {}", self.secret);
+        Action::Continue
+    }
+}

--- a/plugins/samples/docs_plugin_config/plugin.rs
+++ b/plugins/samples/docs_plugin_config/plugin.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_docs_plugin_config]
 use log::info;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
@@ -48,3 +63,4 @@ impl HttpContext for MyHttpContext {
         Action::Continue
     }
 }
+// [END serviceextensions_plugin_docs_plugin_config]

--- a/plugins/samples/docs_plugin_config/tests.config
+++ b/plugins/samples/docs_plugin_config/tests.config
@@ -1,0 +1,1 @@
+my plugin config

--- a/plugins/samples/docs_plugin_config/tests.textpb
+++ b/plugins/samples/docs_plugin_config/tests.textpb
@@ -1,0 +1,8 @@
+test {
+  name: "CheckSecret"
+  request_headers {
+    result {
+      log { regex: ".*secret: my plugin config\n" }
+    }
+  }
+}


### PR DESCRIPTION
This ensures that the plugins build and behave correctly.
The docs will be updated to embed the code once merged.