### PR TITLE
fix: Specify a bazelisk version in Docker builds (v1.21.0)

### DIFF
--- a/plugins/test/package/Dockerfile
+++ b/plugins/test/package/Dockerfile
@@ -37,7 +37,7 @@ RUN openssl s_client -showcerts -connect github.com:443 \
 RUN update-ca-certificates
 
 # Install bazelisk
-RUN go install github.com/bazelbuild/bazelisk@latest
+RUN go install github.com/bazelbuild/bazelisk@v1.21.0
 ENV PATH="${PATH}:/root/go/bin"
 
 # Debug environment


### PR DESCRIPTION
The latest Bazelisk version has extra dependencies and needs Go 1.21