### PR TITLE
feat: create a Go sample plugin for A/B testing

### DIFF
--- a/plugins/samples/ab_testing/BUILD
+++ b/plugins/samples/ab_testing/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_go", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
 
 licenses(["notice"])  # Apache 2
 
@@ -12,10 +12,16 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
+)
+
 proxy_wasm_tests(
     name = "tests",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
     ],
     tests = ":tests.textpb",
 )

--- a/plugins/samples/ab_testing/plugin.go
+++ b/plugins/samples/ab_testing/plugin.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_ab_testing]
+package main
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net/url"
+	"strings"
+
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+type puginContext struct {
+	types.DefaultPluginContext
+}
+
+type httpContext struct {
+	types.DefaultHttpContext
+}
+
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &puginContext{}
+}
+
+func (*puginContext) NewHttpContext(uint32) types.HttpContext {
+	return &httpContext{}
+}
+
+const (
+	aPath      = "/v1/"
+	bPath      = "/v2/"
+	percentile = 50
+)
+
+// Checks if the current request is eligible to be served by v2 file.
+//
+// The decision is made by hashing the userID into an integer
+// value between 0 and 99, then comparing the hash to a predefined
+// percentile. If the hash value is less than or equal to the percentile,
+// the request is served by the v2 file. Otherwise, it is served by the
+// original file.
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	path, err := proxywasm.GetHttpRequestHeader(":path")
+	if err != types.ErrorStatusNotFound {
+		if err != nil {
+			panic(err)
+		}
+		u, err := url.Parse(path)
+		if err != nil {
+			panic(err)
+		}
+		user := u.Query().Get("user")
+		if user != "" &&
+			strings.HasPrefix(strings.ToLower(path), aPath) &&
+			checkPercentile(user) {
+			newPath := bPath + path[len(aPath):]
+			proxywasm.ReplaceHttpRequestHeader(":path", newPath)
+		}
+	}
+
+	return types.ActionContinue
+}
+
+func checkPercentile(user string) bool {
+	h := fnv.New64a()
+	h.Write([]byte(user))
+	hash := h.Sum64()
+	return int(hash%100) <= percentile
+}
+
+// [START serviceextensions_plugin_ab_testing]

--- a/plugins/samples/ab_testing/plugin.go
+++ b/plugins/samples/ab_testing/plugin.go
@@ -98,4 +98,4 @@ func checkPercentile(user string) bool {
 	return int(hash%100) <= percentile
 }
 
-// [START serviceextensions_plugin_ab_testing]
+// [END serviceextensions_plugin_ab_testing]

--- a/plugins/samples/ab_testing/plugin.go
+++ b/plugins/samples/ab_testing/plugin.go
@@ -34,7 +34,7 @@ type vmContext struct {
 	types.DefaultVMContext
 }
 
-type puginContext struct {
+type pluginContext struct {
 	types.DefaultPluginContext
 }
 
@@ -43,10 +43,10 @@ type httpContext struct {
 }
 
 func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
-	return &puginContext{}
+	return &pluginContext{}
 }
 
-func (*puginContext) NewHttpContext(uint32) types.HttpContext {
+func (*pluginContext) NewHttpContext(uint32) types.HttpContext {
 	return &httpContext{}
 }
 


### PR DESCRIPTION
This plugin is a block request with particular URL/header showcase.

Technically, this is performed by the following hashing algorithm:

1. The user ID is hashed into an integer value between 0 and 99.
1. This integer value is compared to a predefined percentile (e.g., 50%).
1. If the hash value is less than or equal to the percentile, the request is served by v2 file. Otherwise, it is served by its original file.

This examples contains only a Go version.