### PR TITLE
feat: create a Go sample plugin for add header

### DIFF
--- a/plugins/samples/add_header/BUILD
+++ b/plugins/samples/add_header/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_go", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
 
 licenses(["notice"])  # Apache 2
 
@@ -16,11 +16,17 @@ proxy_wasm_plugin_cpp(
     srcs = ["plugin.cc"],
 )
 
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
+)
+
 proxy_wasm_tests(
     name = "tests",
     plugins = [
         ":plugin_cpp.wasm",
         ":plugin_rust.wasm",
+        ":plugin_go.wasm",
     ],
     tests = ":tests.textpb",
 )

--- a/plugins/samples/add_header/plugin.go
+++ b/plugins/samples/add_header/plugin.go
@@ -31,20 +31,20 @@ type vmContext struct {
 	types.DefaultVMContext
 }
 
-func (vc *vmContext) NewPluginContext(contextID uint32) types.PluginContext {
-	return &pluginContext{}
-}
-
 type pluginContext struct {
 	types.DefaultPluginContext
 }
 
-func (pc *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
-	return &myHttpContext{}
-}
-
 type myHttpContext struct {
 	types.DefaultHttpContext
+}
+
+func (vc *vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+func (pc *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &myHttpContext{}
 }
 
 func (ctx *myHttpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
@@ -61,6 +61,7 @@ func (ctx *myHttpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool)
 	if err := proxywasm.ReplaceHttpRequestHeader("Welcome", "warm"); err != nil {
 		panic(err)
 	}
+
 	return types.ActionContinue
 }
 

--- a/plugins/samples/add_header/plugin.go
+++ b/plugins/samples/add_header/plugin.go
@@ -35,7 +35,7 @@ type pluginContext struct {
 	types.DefaultPluginContext
 }
 
-type myHttpContext struct {
+type httpContext struct {
 	types.DefaultHttpContext
 }
 
@@ -44,10 +44,10 @@ func (vc *vmContext) NewPluginContext(contextID uint32) types.PluginContext {
 }
 
 func (pc *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
-	return &myHttpContext{}
+	return &httpContext{}
 }
 
-func (ctx *myHttpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	defer func() {
 		if err := recover(); err != nil {
 			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
@@ -65,7 +65,7 @@ func (ctx *myHttpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool)
 	return types.ActionContinue
 }
 
-func (ctx *myHttpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
 	defer func() {
 		if err := recover(); err != nil {
 			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)

--- a/plugins/samples/add_header/plugin.go
+++ b/plugins/samples/add_header/plugin.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_add_header]
+package main
+
+import (
+	"fmt"
+
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+func (vc *vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+type pluginContext struct {
+	types.DefaultPluginContext
+}
+
+func (pc *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &myHttpContext{}
+}
+
+type myHttpContext struct {
+	types.DefaultHttpContext
+}
+
+func (ctx *myHttpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		if err := recover(); err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+
+	// Add and replace headers.
+	if err := proxywasm.AddHttpRequestHeader("Message", "hello"); err != nil {
+		panic(err)
+	}
+	if err := proxywasm.ReplaceHttpRequestHeader("Welcome", "warm"); err != nil {
+		panic(err)
+	}
+	return types.ActionContinue
+}
+
+func (ctx *myHttpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		if err := recover(); err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+
+	// Conditionally add to a header value.
+	msgValue, err := proxywasm.GetHttpResponseHeader("Message")
+	if err != nil {
+		proxywasm.LogCriticalf("failed to get 'Message' header: %v", err)
+	} else if msgValue == "foo" {
+		if err := proxywasm.AddHttpResponseHeader("Message", "bar"); err != nil {
+			panic(err)
+		}
+	}
+
+	// Unconditionally remove the "Welcome" header.
+	if err := proxywasm.RemoveHttpResponseHeader("Welcome"); err != nil {
+		panic(err)
+	}
+
+	return types.ActionContinue
+}
+
+// [END serviceextensions_plugin_add_header]


### PR DESCRIPTION
This plugin is an add header showcase.

Add new request headers ("Message: hello")
Replace existing request headers ("Welcome: warm")
Conditionally append to response headers (adds "bar" if Message header is "foo")
Remove response headers (removes "Welcome" header)

This example contains only a Go version.