### PR TITLE
feat: create a Go sample for block request with particular URL/header

### DIFF
--- a/plugins/WORKSPACE
+++ b/plugins/WORKSPACE
@@ -212,6 +212,13 @@ go_repository(
     version = "v0.0.0-20241219182957-23e5db51ea08",
 )
 
+go_repository(
+    name = "com_github_com_google_uuid",
+    importpath = "github.com/google/uuid",
+    sum = "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=",
+    version = "v1.6.0",
+)
+
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.24rc1")

--- a/plugins/samples/block_request/BUILD
+++ b/plugins/samples/block_request/BUILD
@@ -1,4 +1,10 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load(
+    "//:plugins.bzl",
+    "proxy_wasm_plugin_cpp",
+    "proxy_wasm_plugin_go",
+    "proxy_wasm_plugin_rust",
+    "proxy_wasm_tests"
+)
 
 licenses(["notice"])  # Apache 2
 
@@ -11,10 +17,19 @@ proxy_wasm_plugin_cpp(
     ],
 )
 
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
+    deps = [
+        "@com_github_com_google_uuid//:go_default_library"
+    ],
+)
+
 proxy_wasm_tests(
     name = "tests",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
     ],
     tests = ":tests.textpb",
 )

--- a/plugins/samples/block_request/plugin.go
+++ b/plugins/samples/block_request/plugin.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_block_request]
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+type pluginContext struct {
+	types.DefaultPluginContext
+}
+
+type httpContext struct {
+	types.DefaultHttpContext
+	pluginContext *pluginContext
+}
+
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+func (*pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
+	uuid.EnableRandPool()
+	return types.OnPluginStartStatusOK
+}
+
+func (*pluginContext) GenerateRequestId() string {
+	uuid := uuid.NewString()
+	return strings.Replace(uuid, "-", "", -1)
+}
+
+func (pluginContext *pluginContext) NewHttpContext(uint32) types.HttpContext {
+	return &httpContext{pluginContext: pluginContext}
+}
+
+const (
+	allowedReferer = "safe-site.com"
+)
+
+// Checks whether the client's Referer header matches an expected domain. If
+// not, generate a 403 Forbidden response.
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	referer, err := proxywasm.GetHttpRequestHeader("Referer")
+	// Check if referer match with the expected domain.
+	if err == types.ErrorStatusNotFound || !strings.Contains(referer, allowedReferer) {
+		requestId := ctx.pluginContext.GenerateRequestId()
+		proxywasm.LogInfof("Forbidden - Request ID: %v", requestId)
+		proxywasm.SendHttpResponse(403, [][2]string{}, []byte(fmt.Sprintf("Forbidden - Request ID: %v", requestId)), 0)
+		return types.ActionPause
+	} else if err != nil {
+		panic(err)
+	}
+
+	// Change it to a meaningful name according to your needs.
+	proxywasm.AddHttpRequestHeader("my-plugin-allowed", "true")
+	return types.ActionContinue
+}
+
+// [END serviceextensions_plugin_block_request]

--- a/plugins/samples/block_request/tests.textpb
+++ b/plugins/samples/block_request/tests.textpb
@@ -19,8 +19,8 @@ test {
     }
     result {
       immediate { http_status: 403 details: "" }
-      body { regex: "Forbidden - Request ID: \\d+" }
-      log { regex: ".+Forbidden - Request ID: \\d+" }
+      body { regex: "Forbidden - Request ID: [[:xdigit:]]+" }
+      log { regex: ".*Forbidden - Request ID: [[:xdigit:]]+" }
       no_header { key: "my-plugin-allowed"}
     }
   }


### PR DESCRIPTION
This plugin is a block request with particular URL/header showcase.

Technically, this is performed checking if the client's referer matches an expected domain. If there's a mismatch, a 403 Forbidden error is returned.

This examples contains only a Go version.