### PR TITLE
feat: create a Go sample for updating http body chunks

### DIFF
--- a/plugins/samples/body_chunking/BUILD
+++ b/plugins/samples/body_chunking/BUILD
@@ -1,10 +1,21 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load(
+    "//:plugins.bzl",
+    "proxy_wasm_plugin_cpp",
+    "proxy_wasm_plugin_go",
+    "proxy_wasm_plugin_rust",
+    "proxy_wasm_tests"
+)
 
 licenses(["notice"])  # Apache 2
 
 proxy_wasm_plugin_cpp(
     name = "plugin_cpp.wasm",
     srcs = ["plugin.cc"],
+)
+
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
 )
 
 proxy_wasm_tests(
@@ -16,6 +27,7 @@ proxy_wasm_tests(
     ],
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
     ],
     tests = ":tests.textpb",
 )

--- a/plugins/samples/body_chunking/plugin.go
+++ b/plugins/samples/body_chunking/plugin.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_body_chunking]
+package main
+
+import (
+	"fmt"
+
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+type pluginContext struct {
+	types.DefaultPluginContext
+}
+
+type httpContext struct {
+	types.DefaultHttpContext
+}
+
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+func (*pluginContext) NewHttpContext(uint32) types.HttpContext {
+	return &httpContext{}
+}
+
+// Add foo onto the end of each request body chunk
+func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	chunk, err := proxywasm.GetHttpRequestBody(0, bodySize)
+	if err != nil {
+		panic(err)
+	}
+	err = proxywasm.ReplaceHttpRequestBody(append(chunk, "foo"...))
+	if err != nil {
+		panic(err)
+	}
+	return types.ActionContinue
+}
+
+// Add bar onto the end of each response body chunk
+func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	chunk, err := proxywasm.GetHttpResponseBody(0, bodySize)
+	if err != nil {
+		panic(err)
+	}
+	err = proxywasm.ReplaceHttpResponseBody(append(chunk, "bar"...))
+	if err != nil {
+		panic(err)
+	}
+	return types.ActionContinue
+}
+
+// [END serviceextensions_plugin_body_chunking]


### PR DESCRIPTION
This plugin is an HTTP body chunking update showcase.

Technically, this is performed by appending some strings onto the body chunking from request and response.

This examples contains only a Go version.