### PR TITLE
feat: create a Go sample for validate http header tokens based on plugin config file

### DIFF
--- a/plugins/samples/config_denylist/BUILD
+++ b/plugins/samples/config_denylist/BUILD
@@ -1,4 +1,10 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load(
+    "//:plugins.bzl",
+    "proxy_wasm_plugin_cpp",
+    "proxy_wasm_plugin_go",
+    "proxy_wasm_plugin_rust",
+    "proxy_wasm_tests"
+)
 
 licenses(["notice"])  # Apache 2
 
@@ -16,11 +22,17 @@ proxy_wasm_plugin_cpp(
     srcs = ["plugin.cc"],
 )
 
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
+)
+
 proxy_wasm_tests(
     name = "tests",
     config = ":tests.config",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
         ":plugin_rust.wasm",
     ],
     tests = ":tests.textpb",
@@ -30,6 +42,7 @@ proxy_wasm_tests(
     name = "noconfig_tests",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
         ":plugin_rust.wasm",
     ],
     tests = ":tests_noconfig.textpb",

--- a/plugins/samples/config_denylist/plugin.go
+++ b/plugins/samples/config_denylist/plugin.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_config_denylist]
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+type pluginContext struct {
+	types.DefaultPluginContext
+	tokens map[string]struct{}
+}
+
+type httpContext struct {
+	types.DefaultHttpContext
+	pluginContext *pluginContext
+}
+
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{tokens: make(map[string]struct{})}
+}
+
+func (ctx *pluginContext) OnPluginStart(int) types.OnPluginStartStatus {
+	config, err := proxywasm.GetPluginConfiguration()
+	if err != types.ErrorStatusNotFound {
+		if err != nil {
+			proxywasm.LogErrorf("Error reading the configuration: %v", err)
+			return types.OnPluginStartStatusFailed
+		}
+		for _, token := range strings.Fields(string(config)) {
+			ctx.tokens[token] = struct{}{}
+		}
+	}
+	proxywasm.LogInfof("Config keys size %v", len(ctx.tokens))
+	return types.OnPluginStartStatusOK
+}
+
+func (ctx *pluginContext) NewHttpContext(uint32) types.HttpContext {
+	return &httpContext{pluginContext: ctx}
+}
+
+func (ctx *pluginContext) IsDeniedUserToken(token string) bool {
+	_, found := ctx.tokens[token]
+	return found
+}
+
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	userToken, err := proxywasm.GetHttpRequestHeader("User-Token")
+	if err != nil {
+		proxywasm.SendHttpResponse(403, [][2]string{}, []byte("Access forbidden - token missing.\n"), 0)
+		return types.ActionPause
+	}
+	if ctx.pluginContext.IsDeniedUserToken(userToken) {
+		proxywasm.SendHttpResponse(403, [][2]string{}, []byte("Access forbidden.\n"), 0)
+		return types.ActionPause
+	}
+	return types.ActionContinue
+}
+
+// [END serviceextensions_plugin_config_denylist]


### PR DESCRIPTION
This plugin is an HTTP token header validation using config file showcase.

Technically, this is performed by validating if the HTTP User token is allowed based on a config file deny list.

This examples contains only a Go version.