### PR TITLE
feat: create a Go sample for the docs plugin config

### DIFF
--- a/plugins/samples/docs_plugin_config/BUILD
+++ b/plugins/samples/docs_plugin_config/BUILD
@@ -1,4 +1,10 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load(
+    "//:plugins.bzl",
+    "proxy_wasm_plugin_cpp",
+    "proxy_wasm_plugin_go",
+    "proxy_wasm_plugin_rust",
+    "proxy_wasm_tests"
+)
 
 licenses(["notice"])  # Apache 2
 
@@ -16,11 +22,17 @@ proxy_wasm_plugin_cpp(
     srcs = ["plugin.cc"],
 )
 
+proxy_wasm_plugin_go(
+    name = "plugin_go.wasm",
+    srcs = ["plugin.go"],
+)
+
 proxy_wasm_tests(
     name = "tests",
     config = ":tests.config",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
         ":plugin_rust.wasm",
     ],
     tests = ":tests.textpb",

--- a/plugins/samples/docs_plugin_config/plugin.go
+++ b/plugins/samples/docs_plugin_config/plugin.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_docs_plugin_config]
+package main
+
+import (
+	"fmt"
+
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
+	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+func init() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	types.DefaultVMContext
+}
+
+type pluginContext struct {
+	types.DefaultPluginContext
+	secret string
+}
+
+type httpContext struct {
+	types.DefaultHttpContext
+	pluginContext *pluginContext
+}
+
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+func (ctx *pluginContext) OnPluginStart(int) types.OnPluginStartStatus {
+	config, err := proxywasm.GetPluginConfiguration()
+	if err != nil {
+		proxywasm.LogErrorf("Error reading the configuration: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+	ctx.secret = string(config)
+	return types.OnPluginStartStatusOK
+}
+
+func (ctx *pluginContext) NewHttpContext(uint32) types.HttpContext {
+	return &httpContext{pluginContext: ctx}
+}
+
+func (ctx *pluginContext) Secret() string {
+	return ctx.secret
+}
+
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	defer func() {
+		err := recover()
+		if err != nil {
+			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+		}
+	}()
+	// Use secret here...
+	proxywasm.LogInfof("secret: %v", ctx.pluginContext.Secret())
+	return types.ActionContinue
+}
+
+// [END serviceextensions_plugin_docs_plugin_config]


### PR DESCRIPTION
This plugin is a Go version from the already implemented in C++ and Rust docs_plugin_config.

This examples contains only a Go version.