### PR TITLE
fix: Remove benchmarks from sample tests

### DIFF
--- a/plugins/samples/add_header/tests.textpb
+++ b/plugins/samples/add_header/tests.textpb
@@ -1,6 +1,5 @@
 test {
   name: "AddsRequestHeader"
-  benchmark: true
   request_headers {
     result {
       has_header { key: "Message" value: "hello" }
@@ -10,7 +9,6 @@ test {
 }
 test {
   name: "UpdatesRequestHeader"
-  benchmark: true
   request_headers {
     input {
       header { key: "Message" value: "hey" }
@@ -37,7 +35,6 @@ test {
 }
 test {
   name: "ExtendsResponseHeader"
-  benchmark: true
   response_headers {
     input { header { key: "Message" value: "foo" } }
     result { has_header { key: "Message" value: "foo, bar" } }
@@ -45,7 +42,6 @@ test {
 }
 test {
   name: "RemovesResponseHeader"
-  benchmark: true
   response_headers {
     input { header { key: "Welcome" value: "any" } }
     result { no_header { key: "Welcome" } }
@@ -54,7 +50,6 @@ test {
 # Behavior is independent of stream.
 test {
   name: "RequestAndResponse"
-  benchmark: true
   request_headers {
     result { has_header { key: "Message" value: "hello" } }
   }

--- a/plugins/samples/regex_rewrite/tests.textpb
+++ b/plugins/samples/regex_rewrite/tests.textpb
@@ -1,7 +1,6 @@
 # Expect no matches, so no changes.
 test {
   name: "NoMatch"
-  benchmark: true
   request_headers {
     input { header { key: ":path" value: "/one/two?three=four" } }
     result { has_header { key: ":path" value: "/one/two?three=four" } }
@@ -10,7 +9,6 @@ test {
 # Expect the plugin to replace the first "foo-" path fragment.
 test {
   name: "MatchAndReplace"
-  benchmark: true
   request_headers {
     input { header { key: ":path" value: "/pre/foo-one/foo-two/post?a=b" } }
     result { has_header { key: ":path" value: "/pre/one/foo-two/post?a=b" } }


### PR DESCRIPTION
Benchmarks in tests caused ASan and TSan tests to occasionally fail due to timeouts.
