### PR TITLE
feat: Add custom stats to benchmarking

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -75,6 +75,7 @@ Tips:
 -   To see plugin-emitted logs on the console, add `--logfile=/dev/stdout`.
 -   To see a trace of logs and wasm ABI calls, add `--loglevel=TRACE`.
 -   To disable benchmarking for faster iteration, add `--nobench`.
+-   To disable unit testing for cleaner output, add `--notest`.
 -   To optionally specify plugin config data, add `--config=<path>`.
 
 You can also run tests using Bazel. This is **much slower** the first time,

--- a/plugins/samples/log_calls/tests.textpb
+++ b/plugins/samples/log_calls/tests.textpb
@@ -1,5 +1,6 @@
 test {
   name: "Logging"
+  benchmark: true
   # Plugin lifecycle tests.
   plugin_init {
     log { regex: ".*root onCreate called" }

--- a/plugins/test/dynamic_test.h
+++ b/plugins/test/dynamic_test.h
@@ -62,17 +62,17 @@ class DynamicTest : public DynamicFixture {
   absl::StatusOr<std::shared_ptr<proxy_wasm::PluginHandleBase>> LoadWasm(
       bool benchmark);
 
-  // Helper to check lifecycle phase side effects (e.g. logging).
+  // Test helper to check lifecycle phase side effects (e.g. logging).
   void CheckSideEffects(const std::string& phase, const pb::Expectation& expect,
                         const TestContext& context);
 
-  // Helper to check phase expectations against outputs.
+  // Test helper to check phase expectations against outputs.
   void CheckPhaseResults(const std::string& phase,
                          const pb::Expectation& expect,
                          const TestContext& context,
                          const TestHttpContext::Result& result);
 
-  // Helper to match string expectations.
+  // Test helper to match string expectations.
   void FindString(const std::string& phase, const std::string& type,
                   const pb::StringMatcher& expect,
                   const std::vector<std::string>& contents);
@@ -81,17 +81,21 @@ class DynamicTest : public DynamicFixture {
   absl::StatusOr<TestHttpContext::Headers> ParseHeaders(const pb::Input& input,
                                                         bool is_request);
 
-  // Helper to generate body string from test config
+  // Helper to generate body string from test config.
   absl::StatusOr<std::string> ParseBodyInput(const pb::Input& input);
 
-  // Helper to break body down into chunks
+  // Helper to break body down into chunks.
   std::vector<std::string> ChunkBody(const std::string& complete_body,
                                      const pb::Test& test);
 
-  // Helper to prep body callbacks for benchmarking
+  // Helper to prep body callbacks for benchmarking.
   absl::StatusOr<std::vector<std::string>> PrepBodyCallbackBenchmark(
       const pb::Test& test,
       google::protobuf::RepeatedPtrField<pb::Invocation> invocations);
+
+  // Bench helper to emit custom stats.
+  void EmitStats(benchmark::State& state, proxy_wasm::PluginHandleBase& handle,
+                 const TestContext& context);
 
   std::string engine_;
   pb::Env env_;

--- a/plugins/test/framework.cc
+++ b/plugins/test/framework.cc
@@ -63,6 +63,7 @@ uint64_t TestContext::getMonotonicTimeNanoseconds() {
 }
 proxy_wasm::WasmResult TestContext::log(uint32_t log_level,
                                         std::string_view message) {
+  logging_bytes_ += message.size();
   if (wasmVm()->cmpLogLevel(proxy_wasm::LogLevel::trace)) {
     std::cout << "TRACE from testcontext: [log] " << message << std::endl;
   }

--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -106,12 +106,14 @@ class TestContext : public proxy_wasm::TestContext {
   // --- BEGIN Testing facilities ---
   // Unsafe access to logs. Not thread safe w.r.t. plugin execution.
   const std::vector<std::string>& phase_logs() const { return phase_logs_; }
+  const uint64_t logging_bytes() const { return logging_bytes_; }
   // Options to customize context behavior.
   ContextOptions& options() const;
   // --- END   Testing facilities ---
 
  protected:
   std::vector<std::string> phase_logs_;
+  uint64_t logging_bytes_ = 0;
 
  private:
   proxy_wasm::BufferBase plugin_config_;

--- a/plugins/test/runner_main.cc
+++ b/plugins/test/runner_main.cc
@@ -19,8 +19,7 @@
 // validates a configured set of expectations about output and side effects.
 //
 // TODO Future features
-// - Publish test runner as Docker image
-// - Structured output (JSON), then convert into product guidance
+// - Structured output (JSON), adding product guidance in output
 // - YAML config input support (--yaml instead of --proto)
 // - Support wasm profiling (https://v8.dev/docs/profile)
 // - Tune v8 compiler (v8_flags.liftoff_only, precompile, etc)
@@ -43,7 +42,8 @@ ABSL_FLAG(std::string, logfile, "", "Emit plugin logs to disk or stdio.");
 ABSL_FLAG(service_extensions_samples::pb::Env::LogLevel, loglevel,
           service_extensions_samples::pb::Env::UNDEFINED,
           "Override log_level.");
-ABSL_FLAG(bool, bench, true, "Option to disable test-requested benchmarks.");
+ABSL_FLAG(bool, test, true, "Option to disable config-requested tests.");
+ABSL_FLAG(bool, bench, true, "Option to disable config-requested benchmarks.");
 
 namespace service_extensions_samples {
 
@@ -144,7 +144,12 @@ absl::Status RunTests(const pb::TestSuite& cfg) {
   }
 
   // Run functional tests.
-  bool tests_ok = RUN_ALL_TESTS() == 0;
+  bool tests_ok = true;
+  if (absl::GetFlag(FLAGS_test)) {
+    tests_ok = RUN_ALL_TESTS() == 0;
+  } else {
+    std::cout << "Skipping tests due to --test=false" << std::endl;
+  }
 
   // Run performance benchmarks.
   if (have_benchmarks) {


### PR DESCRIPTION
Adds stats for memory / logging / binary size in bytes.

The memory stats could use further improvement since they
1. Don't account for stream parallelism
2. Don't give insight into wasm-side allocations

But this is a good enough starting point.

Also adds a flag to optionally disable unit tests.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
