### PR TITLE
Support local response from request body callback

### DIFF
--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -239,6 +239,7 @@ class TestHttpContext : public TestContext {
   // State tracked during a headers call. Invalid otherwise.
   proxy_wasm::WasmHeaderMapType phase_;
   Result result_;
+  bool sent_local_response_ = false;
 
   Buffer body_buffer_;
   CallbackType current_callback_;


### PR DESCRIPTION
The response body callback is not supported since at that point, the body may already be streaming to the downstream client. It is fair to send an immediate response from the request body callback; however.