### PR TITLE
feat: adding new GO callout sample - conditionally receive body

### DIFF
--- a/callouts/go/extproc/cmd/example/main.go
+++ b/callouts/go/extproc/cmd/example/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/examples/basic_callout_server"
 	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/examples/dynamic_forwarding"
 	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/examples/jwt_auth"
+	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/examples/receive_body"
 	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/examples/redirect"
 	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/internal/server"
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -49,6 +50,8 @@ func main() {
 		customService = basic_callout_server.NewExampleCalloutService()
 	case "jwt_auth":
 		customService = jwt_auth.NewExampleCalloutService()
+	case "receive_body":
+		customService = receive_body.NewReceiveBodyCalloutService()
 	case "dynamic_forwarding":
 		customService = dynamic_forwarding.NewExampleCalloutService()
 	default:

--- a/callouts/go/extproc/examples/receive_body/receive_body_server.go
+++ b/callouts/go/extproc/examples/receive_body/receive_body_server.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receive_body
+
+import (
+	extprocconfig "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/internal/server"
+	"github.com/GoogleCloudPlatform/service-extensions/callouts/go/extproc/pkg/utils"
+)
+
+// ReceiveBodyCalloutService is a GRPC callout service that conditionally processes request/response bodies based on headers.
+type ReceiveBodyCalloutService struct {
+	server.GRPCCalloutService
+}
+
+// NewReceiveBodyCalloutService creates a new ReceiveBodyCalloutService with initialized handlers.
+func NewReceiveBodyCalloutService() *ReceiveBodyCalloutService {
+	service := &ReceiveBodyCalloutService{}
+	service.Handlers.RequestHeadersHandler = service.HandleRequestHeaders
+	service.Handlers.RequestBodyHandler = service.HandleRequestBody
+	service.Handlers.ResponseHeadersHandler = service.HandleResponseHeaders
+	service.Handlers.ResponseBodyHandler = service.HandleResponseBody
+	return service
+}
+
+// HandleRequestHeaders processes request headers to conditionally enable streaming body processing.
+func (s *ReceiveBodyCalloutService) HandleRequestHeaders(headers *extproc.HttpHeaders) (*extproc.ProcessingResponse, error) {
+	processBody := false
+
+	// Check for X-Process-Request-Body header
+	for _, h := range headers.GetHeaders().GetHeaders() {
+		if h.GetKey() == "x-process-request-body" && h.GetValue() == "true" {
+			processBody = true
+			break
+		}
+	}
+
+	resp := &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_RequestHeaders{
+			RequestHeaders: utils.AddHeaderMutation(nil, nil, false, nil),
+		},
+	}
+
+	if processBody {
+		resp.ModeOverride = &extprocconfig.ProcessingMode{
+			RequestBodyMode: extprocconfig.ProcessingMode_STREAMED,
+		}
+	}
+
+	return resp, nil
+}
+
+// HandleRequestBody processes streamed request body chunks when enabled.
+func (s *ReceiveBodyCalloutService) HandleRequestBody(body *extproc.HttpBody) (*extproc.ProcessingResponse, error) {
+	processedBody := append(body.GetBody(), []byte("-processed")...)
+	return &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_RequestBody{
+			RequestBody: utils.AddBodyStringMutation(string(processedBody), false),
+		},
+	}, nil
+}
+
+// HandleResponseHeaders processes response headers to conditionally enable streaming body processing.
+func (s *ReceiveBodyCalloutService) HandleResponseHeaders(headers *extproc.HttpHeaders) (*extproc.ProcessingResponse, error) {
+	processBody := false
+
+	// Check for X-Process-Response-Body header
+	for _, h := range headers.GetHeaders().GetHeaders() {
+		if h.GetKey() == "x-process-response-body" && h.GetValue() == "true" {
+			processBody = true
+			break
+		}
+	}
+
+	resp := &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: utils.AddHeaderMutation(nil, nil, false, nil),
+		},
+	}
+
+	if processBody {
+		resp.ModeOverride = &extprocconfig.ProcessingMode{
+			ResponseBodyMode: extprocconfig.ProcessingMode_STREAMED,
+		}
+	}
+
+	return resp, nil
+}
+
+// HandleResponseBody processes streamed response body chunks when enabled.
+func (s *ReceiveBodyCalloutService) HandleResponseBody(body *extproc.HttpBody) (*extproc.ProcessingResponse, error) {
+	processedBody := append(body.GetBody(), []byte("-processed")...)
+	return &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_ResponseBody{
+			ResponseBody: utils.AddBodyStringMutation(string(processedBody), false),
+		},
+	}, nil
+}

--- a/callouts/go/extproc/examples/receive_body/receive_body_server_test.go
+++ b/callouts/go/extproc/examples/receive_body/receive_body_server_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receive_body
+
+import (
+	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocconfig "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestHandleRequestHeaders_EnableStreaming(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	headers := &extproc.HttpHeaders{
+		Headers: &core.HeaderMap{
+			Headers: []*core.HeaderValue{
+				{Key: "x-process-request-body", Value: "true"},
+			},
+		},
+	}
+
+	resp, err := service.HandleRequestHeaders(headers)
+	if err != nil {
+		t.Fatalf("HandleRequestHeaders error: %v", err)
+	}
+
+	if resp.ModeOverride == nil || resp.ModeOverride.RequestBodyMode != extprocconfig.ProcessingMode_STREAMED {
+		t.Errorf("Expected STREAMED request body mode, got: %v", resp.ModeOverride)
+	}
+}
+
+func TestHandleRequestHeaders_NoHeader(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	headers := &extproc.HttpHeaders{
+		Headers: &core.HeaderMap{Headers: []*core.HeaderValue{}},
+	}
+
+	resp, err := service.HandleRequestHeaders(headers)
+	if err != nil {
+		t.Fatalf("HandleRequestHeaders error: %v", err)
+	}
+
+	if resp.ModeOverride != nil {
+		t.Errorf("Expected no mode override, got: %v", resp.ModeOverride)
+	}
+}
+
+func TestHandleRequestBody_Processing(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	body := &extproc.HttpBody{Body: []byte("test")}
+
+	resp, err := service.HandleRequestBody(body)
+	if err != nil {
+		t.Fatalf("HandleRequestBody error: %v", err)
+	}
+
+	expected := &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_RequestBody{
+			RequestBody: &extproc.BodyResponse{
+				Response: &extproc.CommonResponse{
+					BodyMutation: &extproc.BodyMutation{
+						Mutation: &extproc.BodyMutation_Body{
+							Body: []byte("test-processed"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
+		t.Errorf("Response mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestHandleResponseHeaders_EnableStreaming(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	headers := &extproc.HttpHeaders{
+		Headers: &core.HeaderMap{
+			Headers: []*core.HeaderValue{
+				{Key: "x-process-response-body", Value: "true"},
+			},
+		},
+	}
+
+	resp, err := service.HandleResponseHeaders(headers)
+	if err != nil {
+		t.Fatalf("HandleResponseHeaders error: %v", err)
+	}
+
+	if resp.ModeOverride == nil || resp.ModeOverride.ResponseBodyMode != extprocconfig.ProcessingMode_STREAMED {
+		t.Errorf("Expected STREAMED response body mode, got: %v", resp.ModeOverride)
+	}
+}
+
+func TestHandleResponseHeaders_NoHeader(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	headers := &extproc.HttpHeaders{
+		Headers: &core.HeaderMap{Headers: []*core.HeaderValue{}},
+	}
+
+	resp, err := service.HandleResponseHeaders(headers)
+	if err != nil {
+		t.Fatalf("HandleResponseHeaders error: %v", err)
+	}
+
+	if resp.ModeOverride != nil {
+		t.Errorf("Expected no mode override, got: %v", resp.ModeOverride)
+	}
+}
+
+func TestHandleResponseBody_Processing(t *testing.T) {
+	service := NewReceiveBodyCalloutService()
+	body := &extproc.HttpBody{Body: []byte("response")}
+
+	resp, err := service.HandleResponseBody(body)
+	if err != nil {
+		t.Fatalf("HandleResponseBody error: %v", err)
+	}
+
+	expected := &extproc.ProcessingResponse{
+		Response: &extproc.ProcessingResponse_ResponseBody{
+			ResponseBody: &extproc.BodyResponse{
+				Response: &extproc.CommonResponse{
+					BodyMutation: &extproc.BodyMutation{
+						Mutation: &extproc.BodyMutation_Body{
+							Body: []byte("response-processed"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
+		t.Errorf("Response mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add **Conditionally receive body** GO callout samples.

This PR introduces a new callout service that:

- Processes request/response bodies when enabled via headers (x-process-request-body/x-process-response-body)
- Appends "-processed" to each body chunk when streaming is enabled, just for example purposes.
- Includes unit tests for all handlers.

The service can be enabled by specifying "receive_body" in the configuration.