### PR TITLE
fix: Pass end_of_stream bit to onResponseBody and onRequestBody calls in unit testing framework

### DIFF
--- a/plugins/test/framework.cc
+++ b/plugins/test/framework.cc
@@ -188,7 +188,8 @@ TestHttpContext::Result TestHttpContext::SendRequestHeaders(
   return std::move(result_);
 }
 
-TestHttpContext::Result TestHttpContext::SendRequestBody(std::string body) {
+TestHttpContext::Result TestHttpContext::SendRequestBody(std::string body,
+                                                         bool end_of_stream) {
   phase_logs_.clear();
   result_ = Result{};
   if (sent_local_response_) {
@@ -196,8 +197,7 @@ TestHttpContext::Result TestHttpContext::SendRequestBody(std::string body) {
   }
   body_buffer_.setOwned(std::move(body));
   current_callback_ = TestHttpContext::CallbackType::RequestBody;
-  result_.body_status =
-      onRequestBody(body_buffer_.size(), /*end_of_stream=*/false);
+  result_.body_status = onRequestBody(body_buffer_.size(), end_of_stream);
     result_.body = body_buffer_.release();
   return std::move(result_);
 }
@@ -218,7 +218,8 @@ TestHttpContext::Result TestHttpContext::SendResponseHeaders(
   return std::move(result_);
 }
 
-TestHttpContext::Result TestHttpContext::SendResponseBody(std::string body) {
+TestHttpContext::Result TestHttpContext::SendResponseBody(std::string body,
+                                                         bool end_of_stream) {
   phase_logs_.clear();
   result_ = Result{};
   if (sent_local_response_) {
@@ -226,8 +227,7 @@ TestHttpContext::Result TestHttpContext::SendResponseBody(std::string body) {
   }
   body_buffer_.setOwned(std::move(body));
   current_callback_ = TestHttpContext::CallbackType::ResponseBody;
-  result_.body_status =
-      onResponseBody(body_buffer_.size(), /*end_of_stream=*/false);
+  result_.body_status = onResponseBody(body_buffer_.size(), end_of_stream);
   result_.body = body_buffer_.release();
   return std::move(result_);
 }

--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -221,9 +221,9 @@ class TestHttpContext : public TestContext {
 
   // Testing helpers. Use these instead of direct on*Headers methods.
   Result SendRequestHeaders(Headers headers);
-  Result SendRequestBody(std::string body);
+  Result SendRequestBody(std::string body, bool end_of_stream);
   Result SendResponseHeaders(Headers headers);
-  Result SendResponseBody(std::string body);
+  Result SendResponseBody(std::string body, bool end_of_stream);
 
   enum CallbackType {
     None,


### PR DESCRIPTION

Fixes #227. Quoting from that:
"The test runner always passes false for end_of_stream for each body chunk, for both the request body and the response body. It should actually pass true on the last body chunk...It is possible to have end_of_stream = false on the last body chunk if there are HTTP trailers, but the test runner doesn't support HTTP trailers. Therefore for the test runner, end_of_stream should be true for the last body chunk."

Changed files build: I ran `bazel build --config=clang test:all`, with clang-16.
