### PR TITLE
feat: adding new rust plugin sample - add device type

### DIFF
--- a/plugins/samples/add_device_type/BUILD
+++ b/plugins/samples/add_device_type/BUILD
@@ -1,0 +1,20 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "//bazel/cargo/remote:url",
+        "//bazel/cargo/remote:proxy-wasm",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/add_device_type/plugin.rs
+++ b/plugins/samples/add_device_type/plugin.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_device_type]
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(DeviceTypeContext) });
+}}
+
+struct DeviceTypeContext;
+
+impl Context for DeviceTypeContext {}
+
+impl HttpContext for DeviceTypeContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        let user_agent = self.get_http_request_header("user-agent")
+            .unwrap_or_default()
+            .to_lowercase();
+
+        let device_type = detect_device_type(&user_agent);
+        self.set_http_request_header("x-device-type", Some(&device_type));
+
+        Action::Continue
+    }
+}
+
+fn detect_device_type(ua: &str) -> String {
+    if is_bot(ua) {
+        return "bot".to_string();
+    }
+    if is_tablet(ua) {
+        return "tablet".to_string();
+    }
+    if is_mobile(ua) {
+        return "phone".to_string();
+    }
+    if is_desktop(ua) {
+        return "desktop".to_string();
+    }
+    "other".to_string()
+}
+
+fn is_bot(ua: &str) -> bool {
+    let bot_keywords = [
+        "bot", "crawler", "spider", "googlebot", 
+        "bingbot", "slurp", "duckduckbot", "yandexbot", "baiduspider"
+    ];
+    contains_any(ua, &bot_keywords)
+}
+
+fn is_tablet(ua: &str) -> bool {
+    let tablet_keywords = [
+        "ipad", "tablet", "kindle", "tab", 
+        "playbook", "nexus 7", "sm-t", "pad", "gt-p"
+    ];
+    
+    if contains_any(ua, &tablet_keywords) {
+        return true;
+    }
+    
+    if ua.contains("android") {
+        let android_tablet_indicators = ["tablet", "tab", "pad"];
+        return contains_any(ua, &android_tablet_indicators);
+    }
+    
+    false
+}
+
+fn is_mobile(ua: &str) -> bool {
+    let mobile_keywords = [
+        "mobile", "android", "iphone", "ipod", 
+        "blackberry", "windows phone", "webos", "iemobile", "opera mini"
+    ];
+    contains_any(ua, &mobile_keywords)
+}
+
+fn is_desktop(ua: &str) -> bool {
+    let desktop_keywords = [
+        "mozilla", "chrome", "safari", "firefox",
+        "msie", "opera", "edge", "chromium", "vivaldi"
+    ];
+    contains_any(ua, &desktop_keywords)
+}
+
+fn contains_any(s: &str, subs: &[&str]) -> bool {
+    subs.iter().any(|sub| s.contains(sub))
+}
+// [END serviceextensions_plugin_device_type]

--- a/plugins/samples/add_device_type/tests.textpb
+++ b/plugins/samples/add_device_type/tests.textpb
@@ -1,0 +1,92 @@
+# Test desktop user agent detection
+test {
+  name: "DetectDesktopUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" } }
+    result { has_header { key: "x-device-type" value: "desktop" } }
+  }
+}
+
+# Test iPhone detection
+test {
+  name: "DetectIPhoneUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1" } }
+    result { has_header { key: "x-device-type" value: "phone" } }
+  }
+}
+
+# Test iPad detection
+test {
+  name: "DetectIPadUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (iPad; CPU OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1" } }
+    result { has_header { key: "x-device-type" value: "tablet" } }
+  }
+}
+
+# Test Android phone detection
+test {
+  name: "DetectAndroidPhoneUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36" } }
+    result { has_header { key: "x-device-type" value: "phone" } }
+  }
+}
+
+# Test Android tablet detection
+test {
+  name: "DetectAndroidTabletUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (Linux; Android 10; SM-T510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Safari/537.36" } }
+    result { has_header { key: "x-device-type" value: "tablet" } }
+  }
+}
+
+# Test bot detection
+test {
+  name: "DetectBotUserAgent"
+  benchmark: false
+  request_headers {
+    input { header { key: "user-agent" value: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" } }
+    result { has_header { key: "x-device-type" value: "bot" } }
+  }
+}
+
+# Test missing User-Agent
+test {
+  name: "MissingUserAgent"
+  benchmark: false
+  request_headers {
+    input {}
+    result { has_header { key: "x-device-type" value: "other" } }
+  }
+}
+
+# Test case insensitivity
+test {
+  name: "CaseInsensitivity"
+  benchmark: false
+  request_headers {
+    input { header { key: "User-Agent" value: "MOZILLA/5.0 (IPHONE; CPU iPhone OS)" } }
+    result { has_header { key: "x-device-type" value: "phone" } }
+  }
+}
+
+# Test benchmark case for performance testing
+test {
+  name: "BenchmarkDetection"
+  benchmark: true
+  request_headers {
+    input { 
+      header { key: "user-agent" value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" } 
+      header { key: "host" value: "example.com" }
+    }
+    result { has_header { key: "x-device-type" value: "desktop" } }
+  }
+}


### PR DESCRIPTION
This PR introduces a new plugin.rs that implements a device type detection plugin based on the user agent header.

It includes tests to ensure functionality. 
We already have a Pull Requests open for cpp and go.