### PR TITLE
feat: adding new rust plugin sample - hmac token validation

### DIFF
--- a/plugins/bazel/cargo/Cargo.toml
+++ b/plugins/bazel/cargo/Cargo.toml
@@ -13,6 +13,9 @@ url = "2.4"
 # Pin version 2.0.0 until rust-version includes https://github.com/rust-lang/rust/issues/119128
 lol_html = "=2.0.0"
 uuid = { version = "1.12.1", features = [ "v4" ] }
+md5 = "0.7.0"
+hmac = "0.12.1"
+hex = "0.4.3"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/samples/hmac_token_validation/BUILD
+++ b/plugins/samples/hmac_token_validation/BUILD
@@ -1,0 +1,23 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "//bazel/cargo/remote:log",
+        "//bazel/cargo/remote:proxy-wasm",
+        "//bazel/cargo/remote:hmac",
+        "//bazel/cargo/remote:md5",
+        "//bazel/cargo/remote:hex",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/hmac_token_validation/plugin.rs
+++ b/plugins/samples/hmac_token_validation/plugin.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_hmac_token_validation]
+use log::{debug, info, warn};
+use proxy_wasm::{
+    traits::{Context, HttpContext, RootContext},
+    types::{Action, LogLevel},
+};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Debug);
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
+        Box::new(HmacValidationRootContext {
+            secret_key: "your-secret-key".into(),
+            token_validity_seconds: 300,
+        })
+    });
+}}
+
+struct HmacValidationRootContext {
+    secret_key: String,
+    token_validity_seconds: u64,
+}
+
+impl Context for HmacValidationRootContext {}
+
+impl RootContext for HmacValidationRootContext {
+    fn get_type(&self) -> Option<proxy_wasm::types::ContextType> {
+        Some(proxy_wasm::types::ContextType::HttpContext)
+    }
+
+    fn create_http_context(&self, _: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HmacValidationContext {
+            secret_key: self.secret_key.clone(),
+            token_validity_seconds: self.token_validity_seconds,
+        }))
+    }
+}
+
+struct HmacValidationContext {
+    secret_key: String,
+    token_validity_seconds: u64,
+}
+
+impl HmacValidationContext {
+    fn send_error_response(&self, status: u32, body: &'static str, headers: Vec<(&str, &str)>) -> Action {
+        self.send_http_response(
+            status,
+            headers,
+            Some(body.as_bytes()),
+        );
+        Action::Pause
+    }
+
+    fn validate_token(&self, auth_header: &str) -> Result<(), Action> {
+        if auth_header.len() < 5 || !auth_header[..5].eq_ignore_ascii_case("HMAC ") {
+            return Err(self.send_error_response(400, "Invalid Authorization scheme. Use 'HMAC'", vec![]));
+        }
+
+        let token = &auth_header[5..];
+        let (timestamp_str, provided_hmac) = token.split_once(':').ok_or_else(|| 
+            self.send_error_response(400, "Invalid token format: expected 'timestamp:hmac'", vec![])
+        )?;
+
+        let timestamp = timestamp_str.parse::<i64>().map_err(|_| 
+            self.send_error_response(400, "Invalid timestamp", vec![])
+        )?;
+
+        let current_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(i64::MAX);
+
+        if (current_time - timestamp).abs() > self.token_validity_seconds as i64 {
+            return Err(self.send_error_response(403, "Token expired", vec![]));
+        }
+
+        let method = self.get_http_request_header(":method")
+            .ok_or_else(|| self.send_error_response(400, "Missing :method header", vec![]))?;
+
+        let path = self.get_http_request_header(":path")
+            .ok_or_else(|| self.send_error_response(400, "Missing :path header", vec![]))?;
+
+        let message = format!("{}:{}:{}", method, path, timestamp_str);
+        let computed_hmac = compute_md5(&format!("{}{}", self.secret_key, message));
+
+        debug!(
+            "HMAC validation: method={} path={} timestamp={} received={} expected={}",
+            method, path, timestamp_str, provided_hmac, computed_hmac
+        );
+
+        if computed_hmac != provided_hmac {
+            let client_ip = self.get_http_request_header("x-forwarded-for").unwrap_or_default();
+            warn!("Invalid HMAC from {}", client_ip);
+            Err(self.send_error_response(403, "Invalid HMAC", vec![]))
+        } else {
+            info!("Valid HMAC for path: {}", path);
+            Ok(())
+        }
+    }
+}
+
+impl Context for HmacValidationContext {}
+
+impl HttpContext for HmacValidationContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        match self.get_http_request_header("authorization") {
+            Some(auth_header) => self.validate_token(&auth_header)
+                .and(Ok(Action::Continue))
+                .unwrap_or(Action::Pause),
+            None => self.send_error_response(
+                401, 
+                "Missing Authorization header", 
+                vec![("WWW-Authenticate", "HMAC realm=\"api\"")]
+            ),
+        }
+    }
+}
+
+fn compute_md5(input: &str) -> String {
+    let digest = md5::compute(input);
+    format!("{:x}", digest)
+}
+// [END serviceextensions_plugin_hmac_token_validation]

--- a/plugins/samples/hmac_token_validation/tests.textpb
+++ b/plugins/samples/hmac_token_validation/tests.textpb
@@ -1,0 +1,76 @@
+env {
+  log_level: DEBUG
+  log_path: "/dev/stdout"
+}
+
+test {
+  name: "Invalid_HMAC_Format"
+  request_headers {
+    input {
+      header { key: ":path" value: "/api" }
+      header { key: ":method" value: "GET" }
+      header { key: "authorization" value: "HMAC invalid_timestamp" }
+    }
+    result {
+      immediate { http_status: 400 }
+    }
+  }
+}
+
+test {
+  name: "Missing_Authorization_Header"
+  request_headers {
+    input {
+      header { key: ":path" value: "/api" }
+      header { key: ":method" value: "GET" }
+    }
+    result {
+      immediate { http_status: 401 }
+    }
+  }
+}
+
+test {
+  name: "Invalid_HMAC_Value"
+  request_headers {
+    input {
+      header { key: ":path" value: "/api" }
+      header { key: ":method" value: "GET" }
+      # Timestamp válido (current_time - 150s)
+      header { key: "authorization" value: "HMAC 1717000000:invalid_hmac_value" }
+    }
+    result {
+      immediate { http_status: 403 }
+    }
+  }
+}
+
+test {
+  name: "Case_Insensitive_Scheme"
+  request_headers {
+    input {
+      header { key: ":path" value: "/api" }
+      header { key: ":method" value: "GET" }
+      # Timestamp válido (current_time - 150s)
+      header { key: "authorization" value: "hmac 1717000000:valid_hmac" }
+    }
+    result {
+      immediate { http_status: 403 }
+    }
+  }
+}
+
+test {
+  name: "Expired_Token"
+  request_headers {
+    input {
+      header { key: ":path" value: "/api" }
+      header { key: ":method" value: "GET" }
+      # Timestamp expirado (current_time - 301s)
+      header { key: "authorization" value: "HMAC 1710000000:hmac_value" }
+    }
+    result {
+      immediate { http_status: 403 }
+    }
+  }
+}


### PR DESCRIPTION
This Pull Request adds a Rust WASM plugin that implements validating an MD5 signature with HMAC.

- Verifies token freshness against configurable expiry period.
- Computes HMAC-MD5 signatures of request data.
- Rejects requests with invalid/missing tokens.

It also includes BUILD files and test cases covering invalid formats, missing headers, signature validation, and token expiration.