### PR TITLE
feat: add support for running background streams in plugin benchmarks

### DIFF
--- a/plugins/test/BUILD
+++ b/plugins/test/BUILD
@@ -27,6 +27,8 @@ cc_library(
     deps = [
         ":framework",
         ":runner_cc_proto",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/random:distributions",
         "@com_github_google_quiche//quiche:balsa",
         "@com_google_benchmark//:benchmark",
         "@com_google_googletest//:gtest",

--- a/plugins/test/dynamic_test.h
+++ b/plugins/test/dynamic_test.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "absl/random/random.h"
 #include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "test/framework.h"
@@ -100,6 +101,7 @@ class DynamicTest : public DynamicFixture {
   std::string engine_;
   pb::Env env_;
   pb::Test cfg_;
+  absl::BitGen bitgen_;
 };
 
 }  // namespace service_extensions_samples

--- a/plugins/test/runner.proto
+++ b/plugins/test/runner.proto
@@ -148,12 +148,19 @@ message Env {
   string log_path = 5;
   // Fixed timestamp in Unix seconds. If unset it will be the Unix epoch.
   optional uint64 time_secs = 6;
-  // Number of background streams to run in benchmarks. If unset, no background
-  // streams will be run.
-  optional uint64 num_background_streams = 7;
-  // If there are background streams, this controls the number of background
-  // streams that are advanced per iteration of the benchmark loop.
-  optional uint64 background_stream_advance_rate = 8;
+  // Number of additional streams to run in benchmarks. If unset, no additional
+  // streams will be run. CPU time incurred by additional streams is not
+  // included in benchmark results, but memory usage is. This is to enable
+  // testing the CPU cost of a single stream while the plugin is loaded with
+  // other streams, which may catch memory usage issues or performance issues
+  // with algorithmic inefficiencies with a large number of in-flight requests.
+  optional uint64 num_additional_streams = 7;
+  // If there are additional streams, this controls the number of additional
+  // streams that are advanced per iteration of the benchmark loop. E.g. if set
+  // to 3, then with each benchmark cycle, 3 randomly chosen additional streams
+  // will perform a plugin callback to send request or response headers, or
+  // deliver a body chunk.
+  optional uint64 additional_stream_advance_rate = 8;
 }
 
 message TestSuite {

--- a/plugins/test/runner.proto
+++ b/plugins/test/runner.proto
@@ -147,7 +147,13 @@ message Env {
   // Log file to receive plugin output. Can be /dev/std{out,err}.
   string log_path = 5;
   // Fixed timestamp in Unix seconds. If unset it will be the Unix epoch.
-  uint64 time_secs = 6;
+  optional uint64 time_secs = 6;
+  // Number of background streams to run in benchmarks. If unset, no background
+  // streams will be run.
+  optional uint64 num_background_streams = 7;
+  // If there are background streams, this controls the number of background
+  // streams that are advanced per iteration of the benchmark loop.
+  optional uint64 background_stream_advance_rate = 8;
 }
 
 message TestSuite {

--- a/plugins/test/runner_main.cc
+++ b/plugins/test/runner_main.cc
@@ -46,10 +46,10 @@ ABSL_FLAG(service_extensions_samples::pb::Env::LogLevel, loglevel,
           "Override log_level.");
 ABSL_FLAG(bool, test, true, "Option to disable config-requested tests.");
 ABSL_FLAG(bool, bench, true, "Option to disable config-requested benchmarks.");
-ABSL_FLAG(uint64_t, num_background_streams, 0,
-          "Number of background streams to run in benchmarks.");
-ABSL_FLAG(std::optional<uint64_t>, background_stream_advance_rate, std::nullopt,
-          "Number of background streams to advance per benchmark iteration.");
+ABSL_FLAG(uint64_t, num_additional_streams, 0,
+          "Number of additional streams to run in benchmarks.");
+ABSL_FLAG(uint64_t, additional_stream_advance_rate, 0,
+          "Number of additional streams to advance per benchmark iteration.");
 
 namespace service_extensions_samples {
 
@@ -88,9 +88,9 @@ absl::StatusOr<pb::TestSuite> ParseInputs(int argc, char** argv) {
   std::string config_override = absl::GetFlag(FLAGS_config);
   pb::Env::LogLevel mll_override = absl::GetFlag(FLAGS_loglevel);
   std::string logfile = absl::GetFlag(FLAGS_logfile);
-  uint64_t num_background_streams = absl::GetFlag(FLAGS_num_background_streams);
-  std::optional<uint64_t> background_stream_advance_rate =
-      absl::GetFlag(FLAGS_background_stream_advance_rate);
+  uint64_t num_additional_streams = absl::GetFlag(FLAGS_num_additional_streams);
+  uint64_t additional_stream_advance_rate =
+      absl::GetFlag(FLAGS_additional_stream_advance_rate);
   if (!plugin_override.empty()) {
     tests.mutable_env()->set_wasm_path(plugin_override);
   }
@@ -103,12 +103,12 @@ absl::StatusOr<pb::TestSuite> ParseInputs(int argc, char** argv) {
   if (!logfile.empty()) {
     tests.mutable_env()->set_log_path(logfile);
   }
-  if (num_background_streams > 0) {
-    tests.mutable_env()->set_num_background_streams(num_background_streams);
+  if (num_additional_streams > 0) {
+    tests.mutable_env()->set_num_additional_streams(num_additional_streams);
   }
-  if (background_stream_advance_rate.has_value()) {
-    tests.mutable_env()->set_background_stream_advance_rate(
-        *background_stream_advance_rate);
+  if (additional_stream_advance_rate > 0) {
+    tests.mutable_env()->set_additional_stream_advance_rate(
+        additional_stream_advance_rate);
   }
   if (tests.env().log_level() == pb::Env::TRACE) {
     std::cout << "TRACE from runner: final config:\n" << tests.DebugString();

--- a/plugins/test/runner_main.cc
+++ b/plugins/test/runner_main.cc
@@ -24,6 +24,8 @@
 // - Support wasm profiling (https://v8.dev/docs/profile)
 // - Tune v8 compiler (v8_flags.liftoff_only, precompile, etc)
 
+#include <cstdint>
+
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/strings/substitute.h"
@@ -44,6 +46,10 @@ ABSL_FLAG(service_extensions_samples::pb::Env::LogLevel, loglevel,
           "Override log_level.");
 ABSL_FLAG(bool, test, true, "Option to disable config-requested tests.");
 ABSL_FLAG(bool, bench, true, "Option to disable config-requested benchmarks.");
+ABSL_FLAG(uint64_t, num_background_streams, 0,
+          "Number of background streams to run in benchmarks.");
+ABSL_FLAG(std::optional<uint64_t>, background_stream_advance_rate, std::nullopt,
+          "Number of background streams to advance per benchmark iteration.");
 
 namespace service_extensions_samples {
 
@@ -82,6 +88,9 @@ absl::StatusOr<pb::TestSuite> ParseInputs(int argc, char** argv) {
   std::string config_override = absl::GetFlag(FLAGS_config);
   pb::Env::LogLevel mll_override = absl::GetFlag(FLAGS_loglevel);
   std::string logfile = absl::GetFlag(FLAGS_logfile);
+  uint64_t num_background_streams = absl::GetFlag(FLAGS_num_background_streams);
+  std::optional<uint64_t> background_stream_advance_rate =
+      absl::GetFlag(FLAGS_background_stream_advance_rate);
   if (!plugin_override.empty()) {
     tests.mutable_env()->set_wasm_path(plugin_override);
   }
@@ -93,6 +102,13 @@ absl::StatusOr<pb::TestSuite> ParseInputs(int argc, char** argv) {
   }
   if (!logfile.empty()) {
     tests.mutable_env()->set_log_path(logfile);
+  }
+  if (num_background_streams > 0) {
+    tests.mutable_env()->set_num_background_streams(num_background_streams);
+  }
+  if (background_stream_advance_rate.has_value()) {
+    tests.mutable_env()->set_background_stream_advance_rate(
+        *background_stream_advance_rate);
   }
   if (tests.env().log_level() == pb::Env::TRACE) {
     std::cout << "TRACE from runner: final config:\n" << tests.DebugString();


### PR DESCRIPTION
Adds two command-line flags to the plugin tester:

--num_additional_streams
    Specifies the number of additional streams to instantiate in benchmarks.

--additional_stream_advance_rate
    If additional streams are configured, specifies how many background
    streams to advance the state of in each benchmark cycle.

Additional streams are instantiated and advanced outside of the benchmark timer. They pass the same headers and body inputs to the plugin that are specified for the test case being benchmarked.

Example usage:
```
$ cd plugins/
$ bazelisk build ...
$ bazel-bin/test/runner \
    --proto=samples/add_response_header/tests.textpb \
    --plugin=bazel-bin/samples/add_response_header/plugin_cpp.wasm \
    --num_additional_streams=1000 \
    --additional_stream_advance_rate=5
```

The num_additional_streams and additional_stream_advance_rate values can also be configured by setting the corresponding fields of the service_extensions.samples.pb.Env protobuf.

Fixes #191
