### PR TITLE
feat: improving wasm tracing for string params

### DIFF
--- a/plugins/test/framework.cc
+++ b/plugins/test/framework.cc
@@ -62,10 +62,14 @@ uint64_t TestContext::getMonotonicTimeNanoseconds() {
   return absl::ToUnixNanos(options().clock_time);
 }
 proxy_wasm::WasmResult TestContext::log(uint32_t log_level,
-                                        std::string_view message) {
+  std::string_view message) {
   logging_bytes_ += message.size();
   if (wasmVm()->cmpLogLevel(proxy_wasm::LogLevel::trace)) {
-    std::cout << "TRACE from testcontext: [log] " << message << std::endl;
+    std::cout << "TRACE from integration: [vm->host] env.proxy_log(" 
+    << log_level << ", " 
+    << reinterpret_cast<uint64_t>(message.data()) << ", " 
+    << message.size() << ") \"" 
+    << message << "\"" << std::endl;
   }
   if (wasmVm()->cmpLogLevel(static_cast<proxy_wasm::LogLevel>(log_level))) {
     phase_logs_.emplace_back(message);


### PR DESCRIPTION
Fixes #195

This PR updates the logging mechanism in TestContext::log by enhancing the output format. The previous implementation simply printed the log message, while the new version provides more context by displaying the log level, memory address of the message, and its size.

This change will improve our debugging and tracing capabilities, making it easier to monitor logs and evaluate performance during development. Feel free to modify it as necessary!