### PR TITLE
fix: Create an attachment per revision

### DIFF
--- a/.github/workflows/plugins-publish-samples.yml
+++ b/.github/workflows/plugins-publish-samples.yml
@@ -100,12 +100,8 @@ jobs:
         shell: bash
         working-directory: ./plugins
         run: >
-          gcloud artifacts attachments delete \
-            ${{ matrix.image }}-licenses \
-            --location=us --repository=${{ env.REPOSITORY }} \
-            --quiet || true;  # Allow failure
           gcloud artifacts attachments create \
-            ${{ matrix.image }}-licenses \
+            ${{ matrix.image }}-licenses-${{ github.sha }} \
             --location=us --repository=${{ env.REPOSITORY }} \
             --target=${{ fromJSON(steps.meta.outputs.json).tags[0] }} \
             --attachment-type=text/LICENSES \

--- a/.github/workflows/plugins-publish-samples.yml
+++ b/.github/workflows/plugins-publish-samples.yml
@@ -100,6 +100,10 @@ jobs:
         shell: bash
         working-directory: ./plugins
         run: >
+          gcloud artifacts attachments delete \
+            ${{ matrix.image }}-licenses-${{ github.sha }} \
+            --location=us --repository=${{ env.REPOSITORY }} \
+            --quiet || true;  # Allow failure
           gcloud artifacts attachments create \
             ${{ matrix.image }}-licenses-${{ github.sha }} \
             --location=us --repository=${{ env.REPOSITORY }} \


### PR DESCRIPTION
Attachments are auto-deleted with their artifacts:
https://cloud.google.com/artifact-registry/docs/manage-metadata-with-attachments#delete_indirect
