### PR TITLE
chore: Bump proto dependency (CVE-2025-4565)

### DIFF
--- a/callouts/python/requirements.txt
+++ b/callouts/python/requirements.txt
@@ -1,2 +1,2 @@
 grpcio==1.62.2
-protobuf==4.25.3
+protobuf==4.25.8


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
