### PR TITLE
feat: add 10-digit code masking and force identity encoding to enable body scanning in GO check_pii plugin

### DIFF
--- a/plugins/samples/check_pii/BUILD
+++ b/plugins/samples/check_pii/BUILD
@@ -1,4 +1,4 @@
-load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_go", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+load("//:plugins.bzl", "proxy_wasm_plugin_cpp", "proxy_wasm_plugin_go", "proxy_wasm_tests")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,6 +19,7 @@ proxy_wasm_tests(
     name = "tests",
     plugins = [
         ":plugin_cpp.wasm",
+        ":plugin_go.wasm",
     ],
     tests = ":tests.textpb",
 )

--- a/plugins/samples/check_pii/README.md
+++ b/plugins/samples/check_pii/README.md
@@ -1,35 +1,34 @@
 # Check PII Plugin
 
-This plugin detects and masks credit card numbers in HTTP response headers and bodies to prevent accidental exposure of personally identifiable information (PII). It uses regular expressions to find credit card numbers in a 19-character hyphenated format (e.g., `1234-5678-9123-4567`) and masks the first 12 digits while preserving the last 4 digits (e.g., `XXXX-XXXX-XXXX-4567`). The plugin only activates when the response includes a `google-run-pii-check: true` header. Use this plugin when you need to sanitize sensitive data in responses, implement data loss prevention (DLP), or ensure compliance with privacy regulations. It operates during the **response headers** and **response body** processing phases.
+This plugin detects and masks sensitive numbers such as credit card numbers and 10-digit numeric codes in HTTP response headers and bodies to prevent accidental exposure of personally identifiable information (PII). It uses regular expressions to find credit card numbers in a 19-character hyphenated format (e.g., `1234-5678-9123-4567`) and masks the first 12 digits while preserving the last 4 digits (e.g., `XXXX-XXXX-XXXX-4567`). Additionally, it detects 10-digit codes and masks the first 7 digits (e.g., `XXXXXXX123`). Use this plugin when you need to sanitize sensitive data in responses, implement data loss prevention (DLP), or ensure compliance with privacy regulations. It operates during the **request headers**, **response headers**, and **response body** processing phases.
 
 ## How It Works
 
-1. The proxy receives an HTTP response from the upstream server and invokes the plugin's `on_http_response_headers` callback.
-2. The plugin checks if the `google-run-pii-check` header is present and set to `"true"`.
-3. If PII checking is enabled:
-   - The plugin scans all response headers for credit card numbers matching the pattern `\d{4}-\d{4}-\d{4}-(\d{4})`.
-   - For each match, the plugin replaces the first 12 digits with `XXXX-XXXX-XXXX-` while preserving the last 4 digits.
-   - The plugin sets an internal flag (`check_body_`) to indicate that the response body should also be checked.
-4. When the response body arrives, the plugin invokes `on_http_response_body`:
-   - If the `check_body_` flag is set, the plugin scans the entire body for credit card numbers.
-   - The plugin applies the same masking pattern, replacing matched numbers with `XXXX-XXXX-XXXX-[last 4 digits]`.
-5. The plugin returns `Action::Continue`, forwarding the sanitized response to the client.
+1. The proxy receives an HTTP request and invokes the plugin's `on_http_request_headers` callback.
+   - The plugin forces uncompressed responses by changing the `Accept-Encoding` header to `identity`, as compressed bodies cannot be regex-matched directly.
+2. The proxy receives the HTTP response from the upstream server and invokes the plugin's `on_http_response_headers`.
+   - The plugin scans all response headers for credit card numbers and 10-digit codes.
+   - For each match, the plugin replaces the first digits appropriately.
+3. When the response body arrives, the plugin invokes `on_http_response_body`:
+   - The plugin scans the response body chunks.
+   - It applies the same masking patterns, replacing matched numbers while preserving the final digits.
+4. The plugin returns `Action::Continue`, forwarding the sanitized response to the client.
 
-**Important limitation**: For simplicity, this plugin does not handle credit card numbers that are split across multiple `on_http_response_body` calls (chunk boundaries). In production, you would need to implement buffering or stateful pattern matching to handle this edge case.
+**Important limitation**: For simplicity, this plugin does not handle credit card numbers or codes that are split across multiple `on_http_response_body` calls (chunk boundaries). It also prevents response compression to allow body scanning. In production, you would need to implement buffering or stateful pattern matching to handle chunking, and possibly decompress/recompress payloads.
 
 ## Implementation Notes
 
-- **Regular expression compilation**: The regex is compiled once during plugin initialization (`onConfigure` or `NewPluginContext`) for optimal performance.
-- **Conditional execution**: Processing is bypassed entirely unless the specific `google-run-pii-check` header is present and set to true.
-- **Header sweeping**: The plugin iterates through all response headers, matching and masking credit card numbers in-place.
-- **Body scanning**: The response body is fully read into a buffer, scanned against the regex pattern, and replaced if matches occur.
+- **Regular expression compilation**: The regex patterns are compiled once during plugin initialization (`onConfigure` or `NewPluginContext`) for optimal performance.
+- **Header sweeping**: The plugin iterates through all response headers, matching and masking data in-place.
+- **Body scanning**: The response body bytes are loaded as strings, scanned against the regex patterns, and replaced if matches occur.
+- **Compression handling**: Overwrites `Accept-Encoding` on requests to guarantee plaintext responses from backend.
 
 ## Configuration
 
-No configuration required. The credit card regex pattern and activation header (`google-run-pii-check`) are hardcoded in the plugin source.
+No configuration required. The regex patterns are hardcoded in the plugin source.
 
 **Credit card pattern**: `\d{4}-\d{4}-\d{4}-(\d{4})` (19 characters with hyphens)  
-**Activation header**: `google-run-pii-check: true`
+**10-Digit Code pattern**: `\d{7}(\d{3})`
 
 ## Build
 
@@ -64,10 +63,17 @@ Derived from [`tests.textpb`](tests.textpb):
 
 | Scenario | Description |
 |---|---|
-| **WithRunCheckHeaderOverwriteCardNumberOnResponseHeader** | Correctly masks credit card numbers in response headers when the check is enabled. |
-| **WithoutRunCheckHeaderKeepTheOriginalHeaders** | Leaves response headers untouched when the PII check is disabled. |
-| **WithRunCheckHeaderOverwriteCardNumberOnBody** | Correctly masks multiple credit card numbers within the response body when enabled. |
-| **WithoutRunCheckHeaderKeepTheOriginalBody** | Leaves the response body untouched when the PII check is disabled. |
+| **OverwriteCardNumberOnResponseHeader** | Correctly masks credit card numbers found in response headers. |
+| **OverwriteCardNumberOnBody** | Correctly masks multiple credit card numbers within the response body. |
+| **Overwrite10DigitCodeOnResponseHeader** | Correctly masks 10-digit codes found in response headers. |
+| **Overwrite10DigitCodeOnResponseBody** | Correctly masks 10-digit codes within the response body. |
+| **OverwritePIIOnResponseBody** | Masks both 10-digit codes and credit card formats correctly within the body. |
+| **OverwriteMultiplePIIInHeadersAndBody** | Successfully masks multiple variations of PII data across both headers and bodies. |
+| **EnsureNonPIIDataRemainsUnchanged** | Leaves headers and body text untouched that do not match the PII formats. |
+| **OverwriteMultiple10DigitCodesInBody** | Handles multiple consecutive 10-digit code instances in the same body content. |
+| **Overwrite10DigitCodesAdjacentToOtherCharacters** | Masks 10-digit codes correctly even when they adjoin text characters. |
+| **OverwritePIIDataAdjacentToOtherCharacters** | Masks credit card formats correctly even when they adjoin text characters. |
+| **OverwriteAcceptEncodingRequestHeader** | Intercepts the request and sets `Accept-Encoding` header to `identity`. |
 
 ## Available Languages
 

--- a/plugins/samples/check_pii/plugin.go
+++ b/plugins/samples/check_pii/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package main
 
 import (
-	"fmt"
+	"bytes"
 	"regexp"
 
 	"github.com/proxy-wasm/proxy-wasm-go-sdk/proxywasm"
@@ -24,6 +24,7 @@ import (
 )
 
 func main() {}
+
 func init() {
 	proxywasm.SetVMContext(&vmContext{})
 }
@@ -33,47 +34,57 @@ type vmContext struct {
 }
 type pluginContext struct {
 	types.DefaultPluginContext
-	creditCardRegex *regexp.Regexp
+	cardMatcher   *regexp.Regexp
+	code10Matcher *regexp.Regexp
 }
 type httpContext struct {
 	types.DefaultHttpContext
-	creditCardRegex *regexp.Regexp
-	checkBody       bool
+	cardMatcher   *regexp.Regexp
+	code10Matcher *regexp.Regexp
 }
 
 func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
-	return &pluginContext{creditCardRegex: regexp.MustCompile("\\d{4}-\\d{4}-\\d{4}-(\\d{4})")}
+	// Compile the regex expressions at plugin setup time for optimal performance.
+	// Credit card numbers in a 16-digit hyphenated format.
+	// 10-digit numeric codes.
+	return &pluginContext{
+		cardMatcher:   regexp.MustCompile(`\d{4}-\d{4}-\d{4}-(\d{4})`),
+		code10Matcher: regexp.MustCompile(`\d{7}(\d{3})`),
+	}
 }
 
-func (pluginContext *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
-	return &httpContext{creditCardRegex: pluginContext.creditCardRegex}
+func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpContext{
+		cardMatcher:   p.cardMatcher,
+		code10Matcher: p.code10Matcher,
+	}
+}
+
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	// Disallow server compression so we can read the plaintext body.
+	err := proxywasm.ReplaceHttpRequestHeader("accept-encoding", "identity")
+	if err != nil {
+		proxywasm.LogErrorf("failed to replace accept-encoding header: %v", err)
+	}
+	return types.ActionContinue
 }
 
 func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
-	defer func() {
-		err := recover()
-		if err != nil {
-			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
-		}
-	}()
-	value, err := proxywasm.GetHttpResponseHeader("google-run-pii-check")
-	if err != nil {
-		panic(err)
-	}
-	if value != "true" {
-		return types.ActionContinue
-	}
-	ctx.checkBody = true
 	headers, err := proxywasm.GetHttpResponseHeaders()
 	if err != nil {
-		panic(err)
+		proxywasm.LogErrorf("failed to get response headers: %v", err)
+		return types.ActionContinue // Fail open
 	}
+
 	for i := range headers {
-		result := ctx.creditCardRegex.ReplaceAllString(headers[i][1], "XXXX-XXXX-XXXX-${1}")
-		if result != headers[i][1] {
-			err = proxywasm.ReplaceHttpResponseHeader(headers[i][0], result)
+		key := headers[i][0]
+		value := headers[i][1]
+
+		maskedValue := ctx.maskPIIString(value)
+		if maskedValue != value {
+			err = proxywasm.ReplaceHttpResponseHeader(key, maskedValue)
 			if err != nil {
-				panic(err)
+				proxywasm.LogErrorf("failed to replace header %s: %v", key, err)
 			}
 		}
 	}
@@ -81,29 +92,42 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 }
 
 func (ctx *httpContext) OnHttpResponseBody(numBytes int, endOfStream bool) types.Action {
-	if !ctx.checkBody {
+	if numBytes == 0 {
 		return types.ActionContinue
 	}
-	defer func() {
-		err := recover()
+
+	body, err := proxywasm.GetHttpResponseBody(0, numBytes)
+	if err != nil {
+		proxywasm.LogErrorf("failed to get response body: %v", err)
+		return types.ActionContinue // Fail open
+	}
+
+	// Note: this example does not handle PII split across chunk boundaries.
+	maskedBody := ctx.maskPIIBytes(body)
+
+	// Only interact with the WASM host if modifications were actually made
+	if !bytes.Equal(body, maskedBody) {
+		err = proxywasm.ReplaceHttpResponseBody(maskedBody)
 		if err != nil {
-			proxywasm.SendHttpResponse(500, [][2]string{}, []byte(fmt.Sprintf("%v", err)), 0)
+			proxywasm.LogErrorf("failed to replace response body: %v", err)
 		}
-	}()
-	bytes, err := proxywasm.GetHttpResponseBody(0, numBytes)
-	if err != nil {
-		panic(err)
 	}
-	// Note that for illustrative purposes, this example is kept simple and does
-	// not handle the case of credit card numbers that are split across multiple
-	// OnHttpResponseBody calls. It therefore does not mask PII spanning chunk
-	// boundaries.
-	bytes = ctx.creditCardRegex.ReplaceAll(bytes, []byte("XXXX-XXXX-XXXX-${1}"))
-	err = proxywasm.ReplaceHttpResponseBody(bytes)
-	if err != nil {
-		panic(err)
-	}
+
 	return types.ActionContinue
+}
+
+// maskPIIString is used for Headers (which are naturally strings)
+func (ctx *httpContext) maskPIIString(value string) string {
+	value = ctx.cardMatcher.ReplaceAllString(value, "XXXX-XXXX-XXXX-${1}")
+	value = ctx.code10Matcher.ReplaceAllString(value, "XXXXXXX${1}")
+	return value
+}
+
+// maskPIIBytes is used for the Body (avoids memory allocation overhead)
+func (ctx *httpContext) maskPIIBytes(value []byte) []byte {
+	value = ctx.cardMatcher.ReplaceAll(value, []byte("XXXX-XXXX-XXXX-${1}"))
+	value = ctx.code10Matcher.ReplaceAll(value, []byte("XXXXXXX${1}"))
+	return value
 }
 
 // [END serviceextensions_plugin_check_pii]


### PR DESCRIPTION
This PR aligns the `GO` implementation and documentation of the `check_pii` plugin with the latest `C++` version.

Added masking for 10-digit numeric codes and removed the `google-run-pii-check` bypass requirement, mirroring `plugin.cc`.

Optimized `OnHttpResponseBody` to manipulate `[]byte` directly, avoiding unnecessary string heap allocations.

Switched to a fail-open strategy (`ActionContinue`) instead of returning 500s (`ActionPause`) on buffer read failures.
Updated `README.md` with the new expected behavior and added `plugin_go.wasm` to the `proxy_wasm_tests` array in `BUILD`.