### PR TITLE
feat: Add a Python Callout implementation for Litellm sample

### DIFF
--- a/callouts/python/extproc/example/litellm_gateway/Dockerfile
+++ b/callouts/python/extproc/example/litellm_gateway/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the proto libraries from the envoy git repo using buf.
+FROM bufbuild/buf AS BUF
+RUN apk add --no-cache git
+COPY ./buf.gen.yaml ./buf.gen.yaml
+ARG proto_path="envoy/service/ext_proc/v3/external_processor.proto"
+RUN buf -v generate https://github.com/envoyproxy/envoy.git#subdir=api \
+      --path $proto_path --include-imports
+
+# Service image. We preserve the package layout (extproc/example/litellm_gateway/...)
+# rather than flattening, because our service module imports siblings via the full
+# package path and relies on running as `python -m extproc.example.litellm_gateway.*`.
+FROM launcher.gcr.io/google/debian12
+
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y \
+ && apt-get install -y python3-pip --no-install-recommends --no-install-suggests \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ./requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt --break-system-packages --root-user-action=ignore
+
+WORKDIR /home/callouts/python
+
+# Generated proto packages drop into WORKDIR root (envoy/, etc.).
+COPY --from=BUF ./protodef .
+
+# Framework + our example, preserving the package structure.
+COPY ./extproc/__init__.py ./extproc/__init__.py
+COPY ./extproc/service ./extproc/service
+COPY ./extproc/ssl_creds ./extproc/ssl_creds
+COPY ./extproc/example/__init__.py ./extproc/example/__init__.py
+COPY ./extproc/example/litellm_gateway ./extproc/example/litellm_gateway
+
+# Example-specific dependencies (litellm, httpx, google-cloud-aiplatform).
+RUN pip install -r ./extproc/example/litellm_gateway/additional-requirements.txt \
+      --break-system-packages --root-user-action=ignore
+
+EXPOSE 80 443 8080
+
+ENTRYPOINT ["python3", "-um", "extproc.example.litellm_gateway.service_callout_example"]

--- a/callouts/python/extproc/example/litellm_gateway/README.md
+++ b/callouts/python/extproc/example/litellm_gateway/README.md
@@ -1,0 +1,344 @@
+# LiteLLM Gateway
+
+A Service Extensions `ext_proc` callout that turns a Google Cloud external
+Application Load Balancer into an **OpenAI-compatible multi-provider gateway**.
+The load balancer routes each request to the right provider backend (Vertex AI,
+Anthropic, Groq, OpenRouter, …); the callout runs **LiteLLM in-process** to
+translate the OpenAI request/response to/from each provider's native format and
+to inject the right auth.
+
+The callout does **not** proxy traffic — it only mutates headers and the body.
+The load balancer forwards the rewritten request straight to the provider via an
+Internet NEG backend.
+
+## Architecture
+
+```
+                              x-v2-target-provider: anthropic
+  Client  ──────────────────────────────────────────────────────────────┐
+   │  POST /v1/chat/completions   (OpenAI body, model="anthropic/claude…") │
+   ▼                                                                      │
+ ┌────────────────────────────────────────────────────────────────────────┴───┐
+ │                    Global External Application LB                            │
+ │                                                                              │
+ │   ┌──────────────────────────┐        ┌──────────────────────────────────┐   │
+ │   │ URL Map                  │        │  Traffic Extension               │   │
+ │   │  /v1/* + header          │  body  │   Callout (ext_proc, Cloud Run)  │   │
+ │   │   x-v2-target-provider:  ├───────►│   - LiteLLM: provider detect     │   │
+ │   │     anthropic → BE-A     │◄───────┤   - LiteLLM: OpenAI→provider body│   │
+ │   │     groq      → BE-G     │ headers │   - inject auth (ADC / API key)  │   │
+ │   │     openrouter→ BE-O     │  + body │   - rewrite :path / :authority   │   │
+ │   │   /v1/*  (default)→ BE-V │        └──────────────────────────────────┘   │
+ │   │   default → upstream UI  │                                               │
+ │   └────────┬─────────────────┘                                               │
+ │            │  LB forwards to the matched backend                             │
+ │            ▼                                                                 │
+ │   ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌────────┐ │
+ │   │ BE-V Vertex │ │ BE-A Anthr. │ │ BE-G Groq   │ │ BE-O OpenR. │ │upstream│ │
+ │   │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ UI app │ │
+ │   └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └────────┘ │
+ └──────────┼───────────────┼───────────────┼───────────────┼───────────────────┘
+            ▼               ▼               ▼               ▼
+   {region}-aiplatform  api.anthropic.com  api.groq.com   openrouter.ai
+   .googleapis.com
+```
+
+On the response, the LB invokes the callout again; LiteLLM transforms the
+provider's response back to OpenAI format (or, for streaming, parses each SSE
+chunk and re-emits it as an OpenAI `chat.completion.chunk`).
+
+## How It Works — step by step
+
+1. **Client** sends a standard OpenAI request (`POST /v1/chat/completions`,
+   body `{"model": "anthropic/claude-3-5-sonnet-…", "messages": […]}`) plus a
+   routing header `x-v2-target-provider: anthropic`.
+2. **URL Map** evaluates `prefix=/v1/` + `header_matches: x-v2-target-provider`
+   and selects the matching backend service (e.g. the Anthropic Internet NEG).
+   `/v1/*` requests with no provider header fall through to the Vertex AI
+   backend; non-LLM paths go to the upstream UI app.
+3. **Traffic Extension** intercepts the request and streams the headers and
+   body to the callout over gRPC (`REQUEST_HEADERS`, then `REQUEST_BODY`).
+4. **Callout** (`service_callout_example.py`) hands the body to LiteLLM:
+   - `litellm.get_llm_provider(model)` → resolves the provider (`anthropic`).
+   - The provider's `Config` class produces the request body in the provider's
+     native format (`config.transform_request(...)`), the target URL
+     (`config.get_complete_url(...)`), and the auth headers
+     (`config.validate_environment(...)`). For Vertex AI the bearer token is
+     minted from the Cloud Run service identity (ADC); for the others the API
+     key comes from a Secret Manager-backed env var.
+   - The callout returns a `BodyResponse` with the transformed body plus header
+     mutations: `:path`, `:authority`/`host`, the auth header(s),
+     `content-length`, `accept-encoding: identity`, a `user-agent`, and
+     `x-litellm-*` provenance markers. **No `clear_route_cache`** — routing was
+     already decided by the URL map.
+5. **Load balancer** forwards the rewritten request to the chosen backend's
+   Internet NEG, which connects to the provider's API.
+6. **Response phase** — the LB invokes the callout again
+   (`RESPONSE_HEADERS`, `RESPONSE_BODY`). The callout drops the upstream
+   `content-length` (stale after the transform) and, on the body, runs the
+   provider `Config`'s `transform_response(...)` to produce an OpenAI
+   `chat.completion`. For streaming responses it parses each SSE event with the
+   provider's chunk iterator and re-emits an OpenAI `chat.completion.chunk`,
+   appending `data: [DONE]\n\n` at the end.
+7. **Client** receives a standard OpenAI response — same shape regardless of
+   which provider served it.
+
+### The `x-v2-target-provider` header
+
+The client sends `x-v2-target-provider: <provider>` alongside the request — the
+URL map matches on it to pick the backend. The provider is the first segment of
+the LiteLLM model id (`anthropic/claude-…` → `anthropic`), so a one-line
+client-side mapping is all that's required. The sample UI sets it automatically
+from the selected model; OpenAI-style SDK clients can set it via
+`default_headers`. A `/v1/*` request with no provider header falls through to
+the Vertex AI backend.
+
+### Supported endpoints
+
+| Path | Type |
+|------|------|
+| `/v1/chat/completions` | Chat |
+| `/v1/completions` | Text completion |
+| `/v1/embeddings` | Embeddings |
+| `/v1/models` | Model discovery |
+| `/chat/completions` | Chat (alias) |
+| `/completions` | Text completion (alias) |
+| `/embeddings` | Embeddings (alias) |
+
+## Providers
+
+The sample ships with four provider backends. The model id (LiteLLM convention,
+`provider/model`) and the `x-v2-target-provider` header both encode the provider:
+
+| Provider | Example model id | `x-v2-target-provider` | Upstream | Auth |
+|----------|------------------|------------------------|----------|------|
+| Vertex AI | `vertex_ai/gemini-2.5-flash` | `vertex_ai` (or omit — it's the default) | `{region}-aiplatform.googleapis.com` | ADC (Cloud Run service identity, `roles/aiplatform.user`) |
+| Anthropic | `anthropic/claude-3-5-sonnet-20241022` | `anthropic` | `api.anthropic.com` | `ANTHROPIC_API_KEY` env var (Secret Manager) |
+| Groq | `groq/compound-beta` | `groq` | `api.groq.com` | `GROQ_API_KEY` env var (Secret Manager) |
+| OpenRouter | `openrouter/openai/gpt-oss-20b:free` | `openrouter` | `openrouter.ai` | `OPENROUTER_API_KEY` env var (Secret Manager) |
+
+LiteLLM owns the actual translation, so adding a provider that LiteLLM already
+supports needs no callout code change — see below.
+
+### Adding a provider
+
+1. Add the provider's FQDN to `local.third_party_providers` in
+   `deploy/terraform/main.tf` — this creates an Internet NEG + backend service
+   and a URL-map `header_matches` rule for it.
+2. If the provider needs an API key, add a `*_api_key` variable
+   (`deploy/terraform/variables.tf`), wire it into the dynamic `env` block of
+   the callout Cloud Run service, and set it in `terraform.tfvars`. The callout
+   reads it as `<PROVIDER>_API_KEY` automatically.
+3. If LiteLLM's `Config` class for the provider exposes `transform_request`
+   directly (most do — only Vertex Gemini needs the small built-in fallback),
+   nothing else changes.
+
+## Deploy to Google Cloud
+
+> There is intentionally **no local-dev path** for this sample — the ext_proc
+> chain depends on a real GCLB URL map with `header_matches` routing, which an
+> Envoy stand-in doesn't replicate faithfully. Deploy to GCP to exercise it.
+
+### Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) authenticated with ADC
+- A GCP project with Vertex AI enabled and Gemini accessible in your region
+- API keys for any non-Vertex providers you want to use
+
+#### IAM roles
+
+Scoped for sample/testing deployments — use least-privilege equivalents in
+production.
+
+| Role | Purpose |
+|------|---------|
+| `roles/compute.admin` | Load balancer, backend services, NEGs |
+| `roles/run.admin` | Cloud Run services, revisions, IAM bindings |
+| `roles/networkservices.admin` | Service Extensions traffic extension |
+| `roles/iam.serviceAccountUser` | Bind the Cloud Run service account |
+| `roles/artifactregistry.admin` | Create repos, push/pull images |
+| `roles/secretmanager.admin` | Create secrets for provider API keys |
+| `roles/serviceusage.serviceUsageAdmin` | Enable required GCP APIs |
+| `roles/cloudbuild.builds.editor` | Submit Cloud Build jobs |
+| `roles/storage.admin` | Cloud Build source staging bucket |
+
+The callout runs under the project's default compute service account by default
+(it carries `roles/editor`, enough for Vertex AI ADC). For tighter scoping,
+create an SA with only `roles/aiplatform.user` and set
+`var.callout_service_account` to its email.
+
+### 1. Authenticate
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### 2. Enable required APIs
+
+```bash
+gcloud services enable \
+  aiplatform.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com \
+  compute.googleapis.com \
+  iam.googleapis.com \
+  networkservices.googleapis.com \
+  run.googleapis.com \
+  secretmanager.googleapis.com
+```
+
+### 3. Create the Artifact Registry repository
+
+```bash
+gcloud artifacts repositories create litellm-gateway \
+  --repository-format=docker --location=us-central1
+```
+
+### 4. Build and push images
+
+Callout image (run from `callouts/python/` — the build context is the package root):
+
+```bash
+cd callouts/python
+gcloud builds submit \
+  --config=extproc/example/litellm_gateway/cloudbuild.yaml \
+  --project=YOUR_PROJECT_ID
+```
+
+(Optional) Sample chat UI image — serves as the upstream app for non-LLM paths
+and lets you exercise the gateway from a browser:
+
+```bash
+cd extproc/example/litellm_gateway/sample-ui
+gcloud builds submit --config=cloudbuild.yaml --project=YOUR_PROJECT_ID
+```
+
+### 5. Configure and apply Terraform
+
+```bash
+cd ../deploy/terraform     # from sample-ui/, or just cd into deploy/terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: project_id, region, callout_image, optional
+# upstream_app_image, and the *_api_key values for the providers you want.
+terraform init
+terraform plan
+terraform apply
+```
+
+API keys you put in `terraform.tfvars` are uploaded to Secret Manager and
+mounted into the callout Cloud Run service as env vars (`secret_key_ref`). They
+never appear as plain env values in the console.
+
+### 6. Test the deployment
+
+```bash
+LB_IP=$(terraform output -raw load_balancer_ip)
+
+# Vertex AI — no header needed (it's the default backend)
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"vertex_ai/gemini-2.5-flash","messages":[{"role":"user","content":"Say hi"}]}'
+
+# Anthropic / Groq / OpenRouter — set x-v2-target-provider
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" -H "x-v2-target-provider: anthropic" \
+  -d '{"model":"anthropic/claude-3-5-sonnet-20241022","max_tokens":64,"messages":[{"role":"user","content":"Say hi"}]}'
+
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" -H "x-v2-target-provider: groq" \
+  -d '{"model":"groq/compound-beta","messages":[{"role":"user","content":"Say hi"}]}'
+
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" -H "x-v2-target-provider: openrouter" \
+  -d '{"model":"openrouter/openai/gpt-oss-20b:free","messages":[{"role":"user","content":"Say hi"}]}'
+
+# Streaming (SSE)
+curl -skN -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"vertex_ai/gemini-2.5-flash","stream":true,"messages":[{"role":"user","content":"Count to 5"}]}'
+```
+
+If you deployed the sample UI as upstream, open `https://$LB_IP/` in a browser
+(accept the self-signed cert) — it sets the `x-v2-target-provider` header for
+you based on the model you pick.
+
+To see the LB pick a different backend per request, enable logging on the
+backend services (the Terraform sets `log_config { enable = true }`) and query:
+
+```bash
+gcloud logging read 'resource.type="http_load_balancer"' \
+  --project=YOUR_PROJECT_ID --limit=10 --freshness=5m \
+  --format="value(timestamp,httpRequest.requestUrl,httpRequest.status,resource.labels.backend_service_name)"
+```
+
+### 7. Tear down
+
+```bash
+terraform destroy
+gcloud artifacts repositories delete litellm-gateway --location=us-central1 --quiet
+gcloud storage rm -r gs://YOUR_PROJECT_ID_cloudbuild/
+```
+
+### What gets deployed
+
+| Resource | Purpose |
+|----------|---------|
+| Cloud Run (callout) | The ext_proc callout — LiteLLM in-process |
+| Cloud Run (upstream) | Handles non-LLM traffic (hello-app or the sample UI) |
+| Global external Application LB | Entry point with a self-signed cert |
+| Internet NEGs (×4) + backend services | Vertex AI, Anthropic, Groq, OpenRouter |
+| Serverless NEGs (×2) | Cloud Run callout + upstream |
+| URL map | `header_matches` routing to provider backends; default → upstream |
+| Traffic Extension | Invokes the callout for LLM paths |
+| Secret Manager secrets | Provider API keys (only the non-empty ones) |
+
+## Testing
+
+```bash
+cd callouts/python
+pip install -r requirements.txt -r requirements-test.txt \
+  -r extproc/example/litellm_gateway/additional-requirements.txt
+python -m pytest extproc/tests/litellm_gateway_test.py -v
+```
+
+The suite is pure unit tests — no gRPC server, no network. It covers the SSE
+parser, the OpenAI→Vertex body fallback, the ext_proc phase handlers (header
+filtering, body rewriting, response transformation, streaming chunk handling),
+and a real end-to-end pass through LiteLLM's Anthropic config (which works
+offline). The Vertex ADC token mint is patched out.
+
+## File structure
+
+```
+litellm_gateway/
+├── service_callout_example.py     # ext_proc callout — LiteLLM in-process
+├── additional-requirements.txt    # litellm, httpx, google-cloud-aiplatform
+├── cloudbuild.yaml                # Cloud Build config for the callout image
+├── Dockerfile                     # Callout container image
+├── README.md
+├── deploy/
+│   └── terraform/
+│       ├── main.tf                # LB, NEGs, backends, URL map, Traffic Ext, secrets
+│       ├── variables.tf
+│       └── terraform.tfvars.example
+└── sample-ui/
+    ├── index.html                 # Chat UI; sets x-v2-target-provider per model
+    ├── Dockerfile
+    └── cloudbuild.yaml
+```
+
+(Unit tests live at `extproc/tests/litellm_gateway_test.py`.)
+
+## Environment variables (callout)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GCP_PROJECT_ID` | — | Required for Vertex AI requests (used to build the Vertex URL and for ADC). |
+| `GCP_REGION` | `us-central1` | Vertex AI region; also the Internet-NEG FQDN (`{region}-aiplatform.googleapis.com`). |
+| `ANTHROPIC_API_KEY` | — | Picked up by LiteLLM for `anthropic/*` models. Set via Secret Manager. |
+| `GROQ_API_KEY` | — | Picked up by LiteLLM for `groq/*` models. |
+| `OPENROUTER_API_KEY` | — | Picked up by LiteLLM for `openrouter/*` models. |
+| `<PROVIDER>_API_KEY` | — | Generic pattern — any provider you add reads `<PROVIDER>_API_KEY`. |

--- a/callouts/python/extproc/example/litellm_gateway/README.md
+++ b/callouts/python/extproc/example/litellm_gateway/README.md
@@ -7,37 +7,37 @@ Anthropic, Groq, OpenRouter, …); the callout runs **LiteLLM in-process** to
 translate the OpenAI request/response to/from each provider's native format and
 to inject the right auth.
 
-The callout does **not** proxy traffic — it only mutates headers and the body.
-The load balancer forwards the rewritten request straight to the provider via an
-Internet NEG backend.
+The callout implementation does **not** itself proxy traffic, it only mutates
+headers and the body. The load balancer forwards the rewritten request straight
+to the provider via an Internet NEG backend.
 
 ## Architecture
 
 ```
-                              x-v2-target-provider: anthropic
-  Client  ──────────────────────────────────────────────────────────────┐
-   │  POST /v1/chat/completions   (OpenAI body, model="anthropic/claude…") │
-   ▼                                                                      │
- ┌────────────────────────────────────────────────────────────────────────┴───┐
- │                    Global External Application LB                            │
- │                                                                              │
- │   ┌──────────────────────────┐        ┌──────────────────────────────────┐   │
- │   │ URL Map                  │        │  Traffic Extension               │   │
- │   │  /v1/* + header          │  body  │   Callout (ext_proc, Cloud Run)  │   │
- │   │   x-v2-target-provider:  ├───────►│   - LiteLLM: provider detect     │   │
- │   │     anthropic → BE-A     │◄───────┤   - LiteLLM: OpenAI→provider body│   │
+                              x-model-id: anthropic/claude-...
+ Client  ────────────────────────────────────────────────────────────────────────┐
+  │  POST /v1/chat/completions   (OpenAI body, model="anthropic/claude…")        │
+  ▼                                                                              │
+ ┌───────────────────────────────────────────────────────────────────────────────┐
+ │                    Global External Application LB                             │
+ │                                                                               │
+ │   ┌──────────────────────────┐         ┌──────────────────────────────────┐   │
+ │   │ URL Map                  │         │  Traffic Extension               │   │
+ │   │  /v1/* + header          │  body   │   Callout (ext_proc, Cloud Run)  │   │
+ │   │   x-v2-target-provider:  ├────────►│   - LiteLLM: provider detect     │   │
+ │   │     anthropic → BE-A     │◄────────┤   - LiteLLM: OpenAI→provider body│   │
  │   │     groq      → BE-G     │ headers │   - inject auth (ADC / API key)  │   │
  │   │     openrouter→ BE-O     │  + body │   - rewrite :path / :authority   │   │
- │   │   /v1/*  (default)→ BE-V │        └──────────────────────────────────┘   │
- │   │   default → upstream UI  │                                               │
- │   └────────┬─────────────────┘                                               │
- │            │  LB forwards to the matched backend                             │
- │            ▼                                                                 │
- │   ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌────────┐ │
- │   │ BE-V Vertex │ │ BE-A Anthr. │ │ BE-G Groq   │ │ BE-O OpenR. │ │upstream│ │
- │   │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ UI app │ │
- │   └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └────────┘ │
- └──────────┼───────────────┼───────────────┼───────────────┼───────────────────┘
+ │   │   /v1/*  (default)→ BE-V │         └──────────────────────────────────┘   │
+ │   │   default → upstream UI  │                                                │
+ │   └────────┬─────────────────┘                                                │
+ │            │  LB forwards to the matched backend                              │
+ │            ▼                                                                  │
+ │   ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌────────┐  │
+ │   │ BE-V Vertex │ │ BE-A Anthr. │ │ BE-G Groq   │ │ BE-O OpenR. │ │upstream│  │
+ │   │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ Internet NEG│ │ UI app │  │
+ │   └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └──────┬──────┘ └────────┘  │
+ └──────────┼───────────────┼───────────────┼───────────────┼────────────────────┘
             ▼               ▼               ▼               ▼
    {region}-aiplatform  api.anthropic.com  api.groq.com   openrouter.ai
    .googleapis.com
@@ -47,19 +47,20 @@ On the response, the LB invokes the callout again; LiteLLM transforms the
 provider's response back to OpenAI format (or, for streaming, parses each SSE
 chunk and re-emits it as an OpenAI `chat.completion.chunk`).
 
-## How It Works — step by step
+## How It Works
 
 1. **Client** sends a standard OpenAI request (`POST /v1/chat/completions`,
    body `{"model": "anthropic/claude-3-5-sonnet-…", "messages": […]}`) plus a
-   routing header `x-v2-target-provider: anthropic`.
-2. **URL Map** evaluates `prefix=/v1/` + `header_matches: x-v2-target-provider`
-   and selects the matching backend service (e.g. the Anthropic Internet NEG).
-   `/v1/*` requests with no provider header fall through to the Vertex AI
-   backend; non-LLM paths go to the upstream UI app.
+   routing header `x-model-id: anthropic/claude-3-5-sonnet-…` (the model id
+   verbatim).
+2. **URL Map** evaluates `prefix=/v1/` + a `prefix_match` on `x-model-id`
+   (e.g. `anthropic/`) and selects the matching backend service (e.g. the
+   Anthropic Internet NEG). `/v1/*` requests with no matching header fall
+   through to the Vertex AI backend; non-LLM paths go to the upstream UI app.
 3. **Traffic Extension** intercepts the request and streams the headers and
    body to the callout over gRPC (`REQUEST_HEADERS`, then `REQUEST_BODY`).
 4. **Callout** (`service_callout_example.py`) hands the body to LiteLLM:
-   - `litellm.get_llm_provider(model)` → resolves the provider (`anthropic`).
+   - `litellm.get_llm_provider(model)` resolves the provider (`anthropic`).
    - The provider's `Config` class produces the request body in the provider's
      native format (`config.transform_request(...)`), the target URL
      (`config.get_complete_url(...)`), and the auth headers
@@ -69,29 +70,29 @@ chunk and re-emits it as an OpenAI `chat.completion.chunk`).
    - The callout returns a `BodyResponse` with the transformed body plus header
      mutations: `:path`, `:authority`/`host`, the auth header(s),
      `content-length`, `accept-encoding: identity`, a `user-agent`, and
-     `x-litellm-*` provenance markers. **No `clear_route_cache`** — routing was
+     `x-litellm-*` provenance markers. **No `clear_route_cache`**: routing was
      already decided by the URL map.
 5. **Load balancer** forwards the rewritten request to the chosen backend's
    Internet NEG, which connects to the provider's API.
-6. **Response phase** — the LB invokes the callout again
+6. **Response phase**: the LB invokes the callout again
    (`RESPONSE_HEADERS`, `RESPONSE_BODY`). The callout drops the upstream
    `content-length` (stale after the transform) and, on the body, runs the
    provider `Config`'s `transform_response(...)` to produce an OpenAI
    `chat.completion`. For streaming responses it parses each SSE event with the
    provider's chunk iterator and re-emits an OpenAI `chat.completion.chunk`,
    appending `data: [DONE]\n\n` at the end.
-7. **Client** receives a standard OpenAI response — same shape regardless of
-   which provider served it.
+7. **Client** receives a standard OpenAI response with the same shape
+   regardless of which provider served it.
 
-### The `x-v2-target-provider` header
+### The `x-model-id` header
 
-The client sends `x-v2-target-provider: <provider>` alongside the request — the
-URL map matches on it to pick the backend. The provider is the first segment of
-the LiteLLM model id (`anthropic/claude-…` → `anthropic`), so a one-line
-client-side mapping is all that's required. The sample UI sets it automatically
-from the selected model; OpenAI-style SDK clients can set it via
-`default_headers`. A `/v1/*` request with no provider header falls through to
-the Vertex AI backend.
+The client includes `x-model-id: <provider>/<model>` as a request header,
+and the URL map prefix-matches the leading `<provider>/` segment to
+pick the backend, so no client-side mapping is needed. The sample UI sets the
+header automatically from the selected model; OpenAI-style SDK clients can set
+it via `default_headers` (client-level) or `extra_headers` (per call).
+A `/v1/*` request with no `x-model-id` header, or one whose prefix does not
+match Anthropic, Groq, or OpenRouter, falls through to the Vertex AI backend.
 
 ### Supported endpoints
 
@@ -107,35 +108,41 @@ the Vertex AI backend.
 
 ## Providers
 
-The sample ships with four provider backends. The model id (LiteLLM convention,
-`provider/model`) and the `x-v2-target-provider` header both encode the provider:
+The sample ships with four provider backends. The model id follows the LiteLLM
+convention `<provider>/<model>`. The `x-model-id` header carries that same
+string verbatim, and the URL map prefix-matches on the leading `<provider>/`
+segment to pick the backend.
 
-| Provider | Example model id | `x-v2-target-provider` | Upstream | Auth |
-|----------|------------------|------------------------|----------|------|
-| Vertex AI | `vertex_ai/gemini-2.5-flash` | `vertex_ai` (or omit — it's the default) | `{region}-aiplatform.googleapis.com` | ADC (Cloud Run service identity, `roles/aiplatform.user`) |
-| Anthropic | `anthropic/claude-3-5-sonnet-20241022` | `anthropic` | `api.anthropic.com` | `ANTHROPIC_API_KEY` env var (Secret Manager) |
-| Groq | `groq/compound-beta` | `groq` | `api.groq.com` | `GROQ_API_KEY` env var (Secret Manager) |
-| OpenRouter | `openrouter/openai/gpt-oss-20b:free` | `openrouter` | `openrouter.ai` | `OPENROUTER_API_KEY` env var (Secret Manager) |
+| Provider | Example model id | Upstream | Auth |
+|----------|------------------|----------|------|
+| Vertex AI | `vertex_ai/gemini-2.5-flash` | `{region}-aiplatform.googleapis.com` | ADC (Cloud Run service identity, `roles/aiplatform.user`) |
+| Anthropic | `anthropic/claude-3-5-sonnet-20241022` | `api.anthropic.com` | `ANTHROPIC_API_KEY` env var (Secret Manager) |
+| Groq | `groq/compound-beta` | `api.groq.com` | `GROQ_API_KEY` env var (Secret Manager) |
+| OpenRouter | `openrouter/openai/gpt-oss-20b:free` | `openrouter.ai` | `OPENROUTER_API_KEY` env var (Secret Manager) |
+
+Vertex AI is the default backend: a request with no `x-model-id` header (or one
+whose provider prefix is none of the three above) falls through to Vertex.
 
 LiteLLM owns the actual translation, so adding a provider that LiteLLM already
-supports needs no callout code change — see below.
+supports needs no callout code change. See below.
 
 ### Adding a provider
 
 1. Add the provider's FQDN to `local.third_party_providers` in
-   `deploy/terraform/main.tf` — this creates an Internet NEG + backend service
+   `deploy/terraform/main.tf`. This creates an Internet NEG + backend service
    and a URL-map `header_matches` rule for it.
 2. If the provider needs an API key, add a `*_api_key` variable
    (`deploy/terraform/variables.tf`), wire it into the dynamic `env` block of
    the callout Cloud Run service, and set it in `terraform.tfvars`. The callout
    reads it as `<PROVIDER>_API_KEY` automatically.
 3. If LiteLLM's `Config` class for the provider exposes `transform_request`
-   directly (most do — only Vertex Gemini needs the small built-in fallback),
+   directly (most do; only Vertex Gemini needs the small built-in fallback),
    nothing else changes.
 
 ## Deploy to Google Cloud
 
-> There is intentionally **no local-dev path** for this sample — the ext_proc
+> [!IMPORTANT]
+> There is intentionally **no local-dev path** for this sample. The ext_proc
 > chain depends on a real GCLB URL map with `header_matches` routing, which an
 > Envoy stand-in doesn't replicate faithfully. Deploy to GCP to exercise it.
 
@@ -148,7 +155,7 @@ supports needs no callout code change — see below.
 
 #### IAM roles
 
-Scoped for sample/testing deployments — use least-privilege equivalents in
+Scoped for sample/testing deployments. Use least-privilege equivalents in
 production.
 
 | Role | Purpose |
@@ -199,7 +206,8 @@ gcloud artifacts repositories create litellm-gateway \
 
 ### 4. Build and push images
 
-Callout image (run from `callouts/python/` — the build context is the package root):
+Callout image (run from `callouts/python/`, since the build context is the
+package root):
 
 ```bash
 cd callouts/python
@@ -208,7 +216,7 @@ gcloud builds submit \
   --project=YOUR_PROJECT_ID
 ```
 
-(Optional) Sample chat UI image — serves as the upstream app for non-LLM paths
+(Optional) Sample chat UI image. Serves as the upstream app for non-LLM paths
 and lets you exercise the gateway from a browser:
 
 ```bash
@@ -237,22 +245,25 @@ never appear as plain env values in the console.
 ```bash
 LB_IP=$(terraform output -raw load_balancer_ip)
 
-# Vertex AI — no header needed (it's the default backend)
+# Vertex AI: no header needed (it's the default backend)
 curl -sk -X POST https://$LB_IP/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"vertex_ai/gemini-2.5-flash","messages":[{"role":"user","content":"Say hi"}]}'
 
-# Anthropic / Groq / OpenRouter — set x-v2-target-provider
+# Anthropic / Groq / OpenRouter: set x-model-id to the model id verbatim
 curl -sk -X POST https://$LB_IP/v1/chat/completions \
-  -H "Content-Type: application/json" -H "x-v2-target-provider: anthropic" \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: anthropic/claude-3-5-sonnet-20241022" \
   -d '{"model":"anthropic/claude-3-5-sonnet-20241022","max_tokens":64,"messages":[{"role":"user","content":"Say hi"}]}'
 
 curl -sk -X POST https://$LB_IP/v1/chat/completions \
-  -H "Content-Type: application/json" -H "x-v2-target-provider: groq" \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: groq/compound-beta" \
   -d '{"model":"groq/compound-beta","messages":[{"role":"user","content":"Say hi"}]}'
 
 curl -sk -X POST https://$LB_IP/v1/chat/completions \
-  -H "Content-Type: application/json" -H "x-v2-target-provider: openrouter" \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: openrouter/openai/gpt-oss-20b:free" \
   -d '{"model":"openrouter/openai/gpt-oss-20b:free","messages":[{"role":"user","content":"Say hi"}]}'
 
 # Streaming (SSE)
@@ -262,8 +273,8 @@ curl -skN -X POST https://$LB_IP/v1/chat/completions \
 ```
 
 If you deployed the sample UI as upstream, open `https://$LB_IP/` in a browser
-(accept the self-signed cert) — it sets the `x-v2-target-provider` header for
-you based on the model you pick.
+(accept the self-signed cert). It sets the `x-model-id` header for you based
+on the model you pick.
 
 To see the LB pick a different backend per request, enable logging on the
 backend services (the Terraform sets `log_config { enable = true }`) and query:
@@ -286,7 +297,7 @@ gcloud storage rm -r gs://YOUR_PROJECT_ID_cloudbuild/
 
 | Resource | Purpose |
 |----------|---------|
-| Cloud Run (callout) | The ext_proc callout — LiteLLM in-process |
+| Cloud Run (callout) | The ext_proc callout, LiteLLM in-process |
 | Cloud Run (upstream) | Handles non-LLM traffic (hello-app or the sample UI) |
 | Global external Application LB | Entry point with a self-signed cert |
 | Internet NEGs (×4) + backend services | Vertex AI, Anthropic, Groq, OpenRouter |
@@ -304,8 +315,8 @@ pip install -r requirements.txt -r requirements-test.txt \
 python -m pytest extproc/tests/litellm_gateway_test.py -v
 ```
 
-The suite is pure unit tests — no gRPC server, no network. It covers the SSE
-parser, the OpenAI→Vertex body fallback, the ext_proc phase handlers (header
+The suite is pure unit tests: no gRPC server, no network. It covers the SSE
+parser, the OpenAI to Vertex body fallback, the ext_proc phase handlers (header
 filtering, body rewriting, response transformation, streaming chunk handling),
 and a real end-to-end pass through LiteLLM's Anthropic config (which works
 offline). The Vertex ADC token mint is patched out.
@@ -314,7 +325,7 @@ offline). The Vertex ADC token mint is patched out.
 
 ```
 litellm_gateway/
-├── service_callout_example.py     # ext_proc callout — LiteLLM in-process
+├── service_callout_example.py     # ext_proc callout, LiteLLM in-process
 ├── additional-requirements.txt    # litellm, httpx, google-cloud-aiplatform
 ├── cloudbuild.yaml                # Cloud Build config for the callout image
 ├── Dockerfile                     # Callout container image
@@ -325,7 +336,7 @@ litellm_gateway/
 │       ├── variables.tf
 │       └── terraform.tfvars.example
 └── sample-ui/
-    ├── index.html                 # Chat UI; sets x-v2-target-provider per model
+    ├── index.html                 # Chat UI; sets x-model-id per model
     ├── Dockerfile
     └── cloudbuild.yaml
 ```
@@ -336,9 +347,9 @@ litellm_gateway/
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GCP_PROJECT_ID` | — | Required for Vertex AI requests (used to build the Vertex URL and for ADC). |
+| `GCP_PROJECT_ID` | (none) | Required for Vertex AI requests (used to build the Vertex URL and for ADC). |
 | `GCP_REGION` | `us-central1` | Vertex AI region; also the Internet-NEG FQDN (`{region}-aiplatform.googleapis.com`). |
-| `ANTHROPIC_API_KEY` | — | Picked up by LiteLLM for `anthropic/*` models. Set via Secret Manager. |
-| `GROQ_API_KEY` | — | Picked up by LiteLLM for `groq/*` models. |
-| `OPENROUTER_API_KEY` | — | Picked up by LiteLLM for `openrouter/*` models. |
-| `<PROVIDER>_API_KEY` | — | Generic pattern — any provider you add reads `<PROVIDER>_API_KEY`. |
+| `ANTHROPIC_API_KEY` | (none) | Picked up by LiteLLM for `anthropic/*` models. Set via Secret Manager. |
+| `GROQ_API_KEY` | (none) | Picked up by LiteLLM for `groq/*` models. |
+| `OPENROUTER_API_KEY` | (none) | Picked up by LiteLLM for `openrouter/*` models. |
+| `<PROVIDER>_API_KEY` | (none) | Generic pattern: any provider you add reads `<PROVIDER>_API_KEY`. |

--- a/callouts/python/extproc/example/litellm_gateway/additional-requirements.txt
+++ b/callouts/python/extproc/example/litellm_gateway/additional-requirements.txt
@@ -1,0 +1,3 @@
+litellm==1.83.0
+httpx>=0.27,<1.0
+google-cloud-aiplatform>=1.50.0

--- a/callouts/python/extproc/example/litellm_gateway/cloudbuild.yaml
+++ b/callouts/python/extproc/example/litellm_gateway/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and pushes the Python ext_proc callout image to Artifact Registry.
+#
+# Submit from callouts/python/:
+#   gcloud builds submit \
+#     --config=extproc/example/litellm_gateway/cloudbuild.yaml \
+#     --project=YOUR_PROJECT_ID
+#
+# The build context is callouts/python/ (the package root).
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/litellm-gateway/callout:latest'
+      - '-f'
+      - 'extproc/example/litellm_gateway/Dockerfile'
+      - '.'
+
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/litellm-gateway/callout:latest'

--- a/callouts/python/extproc/example/litellm_gateway/deploy/terraform/main.tf
+++ b/callouts/python/extproc/example/litellm_gateway/deploy/terraform/main.tf
@@ -53,7 +53,7 @@ resource "google_project_service" "apis" {
 }
 
 # ===================================================================
-# SERVICE ACCOUNT — CALLOUT
+# SERVICE ACCOUNT: CALLOUT
 # ===================================================================
 #
 # The callout uses ADC (via the Cloud Run service identity) to mint Vertex AI
@@ -78,8 +78,9 @@ locals {
   ]))
 
   # Each provider here gets an Internet NEG + backend on the LB. The URL
-  # map matches `prefix=/v1/` + header `x-v2-target-provider:<provider>` to
-  # pick the right backend. Vertex AI is below as a separate resource.
+  # map matches `prefix=/v1/` + `x-model-id` header with a provider prefix
+  # (e.g. `anthropic/...`) to pick the right backend. Vertex AI is below
+  # as a separate resource.
   third_party_providers = {
     anthropic  = "api.anthropic.com"
     groq       = "api.groq.com"
@@ -88,7 +89,7 @@ locals {
 }
 
 # ===================================================================
-# SECRET MANAGER — PROVIDER API KEYS
+# SECRET MANAGER: PROVIDER API KEYS
 # ===================================================================
 
 resource "google_secret_manager_secret" "api_keys" {
@@ -114,7 +115,7 @@ resource "google_secret_manager_secret_iam_member" "callout_accessor" {
 }
 
 # ===================================================================
-# CLOUD RUN — CALLOUT (Python ext_proc service)
+# CLOUD RUN: CALLOUT (Python ext_proc service)
 # ===================================================================
 
 resource "google_cloud_run_v2_service" "callout" {
@@ -220,7 +221,7 @@ resource "google_compute_backend_service" "callout_backend" {
 }
 
 # ===================================================================
-# CLOUD RUN — UPSTREAM APPLICATION (non-LLM traffic, e.g., chat UI)
+# CLOUD RUN: UPSTREAM APPLICATION (non-LLM traffic, e.g., chat UI)
 # ===================================================================
 
 resource "google_cloud_run_v2_service" "upstream_app" {
@@ -274,7 +275,7 @@ resource "google_compute_backend_service" "upstream_backend" {
 }
 
 # ===================================================================
-# VERTEX AI BACKEND — GLOBAL INTERNET NEG
+# VERTEX AI BACKEND: GLOBAL INTERNET NEG
 # ===================================================================
 
 resource "google_compute_global_network_endpoint_group" "vertex_neg" {
@@ -308,7 +309,7 @@ resource "google_compute_backend_service" "vertex_backend" {
 }
 
 # ===================================================================
-# THIRD-PARTY PROVIDER BACKENDS — GLOBAL INTERNET NEGs
+# THIRD-PARTY PROVIDER BACKENDS: GLOBAL INTERNET NEGs
 # ===================================================================
 
 resource "google_compute_global_network_endpoint_group" "provider_neg" {
@@ -345,7 +346,7 @@ resource "google_compute_backend_service" "provider_backend" {
 }
 
 # ===================================================================
-# LOAD BALANCER — GLOBAL EXTERNAL APPLICATION LB
+# LOAD BALANCER: GLOBAL EXTERNAL APPLICATION LB
 # ===================================================================
 
 resource "google_compute_global_address" "lb_ip" {
@@ -371,18 +372,19 @@ resource "google_compute_ssl_certificate" "lb_cert" {
   certificate = tls_self_signed_cert.lb_cert.cert_pem
 }
 
-# URL map: header-based routing — the URL map picks the right provider
-# backend by matching the client-supplied `x-v2-target-provider` header.
+# URL map: header-based routing. The URL map picks the right provider
+# backend by prefix-matching the client-supplied `x-model-id` header
+# (which carries the LiteLLM model id, e.g. `anthropic/claude-...`).
 # The Traffic Extension reads the body, transforms OpenAI → provider format,
 # and rewrites `:path` for the upstream call. It does NOT influence routing
 # (Traffic Extensions can't switch backends post-decision).
 #
 # So the rules are:
-#   /v1/* + x-v2-target-provider=anthropic   → Anthropic backend
-#   /v1/* + x-v2-target-provider=groq        → Groq backend
-#   /v1/* + x-v2-target-provider=openrouter  → OpenRouter backend
-#   /v1/*                                  → Vertex AI backend (default)
-#   anything else                          → upstream sample UI
+#   /v1/* + x-model-id starts with "anthropic/"   : Anthropic backend
+#   /v1/* + x-model-id starts with "groq/"        : Groq backend
+#   /v1/* + x-model-id starts with "openrouter/"  : OpenRouter backend
+#   /v1/*                                          : Vertex AI backend (default)
+#   anything else                                  : upstream sample UI
 resource "google_compute_url_map" "url_map" {
   name            = "litellm-gateway-url-map"
   default_service = google_compute_backend_service.upstream_backend.id
@@ -401,8 +403,8 @@ resource "google_compute_url_map" "url_map" {
       match_rules {
         prefix_match = "/v1/"
         header_matches {
-          header_name  = "x-v2-target-provider"
-          exact_match  = "anthropic"
+          header_name  = "x-model-id"
+          prefix_match = "anthropic/"
         }
       }
       service = google_compute_backend_service.provider_backend["anthropic"].id
@@ -418,8 +420,8 @@ resource "google_compute_url_map" "url_map" {
       match_rules {
         prefix_match = "/v1/"
         header_matches {
-          header_name  = "x-v2-target-provider"
-          exact_match  = "groq"
+          header_name  = "x-model-id"
+          prefix_match = "groq/"
         }
       }
       service = google_compute_backend_service.provider_backend["groq"].id
@@ -435,8 +437,8 @@ resource "google_compute_url_map" "url_map" {
       match_rules {
         prefix_match = "/v1/"
         header_matches {
-          header_name  = "x-v2-target-provider"
-          exact_match  = "openrouter"
+          header_name  = "x-model-id"
+          prefix_match = "openrouter/"
         }
       }
       service = google_compute_backend_service.provider_backend["openrouter"].id
@@ -478,17 +480,23 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule" {
 }
 
 # ===================================================================
-# SERVICE EXTENSIONS — TRAFFIC EXTENSION
+# SERVICE EXTENSIONS: TRAFFIC EXTENSION
 # ===================================================================
 #
 # Traffic Extension on Global LB. The callout sees REQUEST_BODY and does:
 #   1. Body transform OpenAI → provider format (LiteLLM)
 #   2. :path rewrite to the provider-specific path (LiteLLM's get_complete_url)
 #   3. Auth header injection (Authorization for Vertex via ADC, x-api-key
-#      for Anthropic, etc. — all via LiteLLM's validate_environment)
+#      for Anthropic, etc., all via LiteLLM's validate_environment)
 #
 # It does NOT influence routing. Routing was decided by the URL map based on
-# the client's x-v2-target-provider header.
+# the client's x-model-id header.
+#
+# We subscribe to REQUEST_BODY without a streamed request body mode, so the LB
+# delivers the request body BUFFERED (the whole body in one message). The
+# callout's on_request_body relies on this to parse the JSON in a single pass.
+# The response body mode is chosen per request by the callout via mode_override
+# (STREAMED for SSE, BUFFERED otherwise).
 
 resource "google_network_services_lb_traffic_extension" "callout" {
   name                  = "litellm-gateway-traffic-ext"
@@ -540,15 +548,15 @@ output "vertex_endpoint" {
 output "curl_test_command" {
   description = "Example curl command to test the LiteLLM gateway through the load balancer."
   value       = <<-EOT
-    # Vertex AI (no header needed — default)
+    # Vertex AI (no header needed; default)
     curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
       -H "Content-Type: application/json" \
       -d '{"model": "vertex_ai/gemini-2.5-flash", "messages": [{"role": "user", "content": "Hello"}]}'
 
-    # Anthropic / Groq / OpenRouter — set x-v2-target-provider header
+    # Anthropic / Groq / OpenRouter: set x-model-id header with the model id
     curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "x-v2-target-provider: anthropic" \
+      -H "x-model-id: anthropic/claude-haiku-4-5" \
       -d '{"model": "anthropic/claude-haiku-4-5", "messages": [{"role": "user", "content": "Hello"}]}'
   EOT
 }

--- a/callouts/python/extproc/example/litellm_gateway/deploy/terraform/main.tf
+++ b/callouts/python/extproc/example/litellm_gateway/deploy/terraform/main.tf
@@ -1,0 +1,554 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.15.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# ===================================================================
+# ENABLE REQUIRED APIS
+# ===================================================================
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "aiplatform.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "networkservices.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# ===================================================================
+# SERVICE ACCOUNT — CALLOUT
+# ===================================================================
+#
+# The callout uses ADC (via the Cloud Run service identity) to mint Vertex AI
+# bearer tokens. The SA therefore needs roles/aiplatform.user.
+#
+# By default the project's default compute SA is used (has roles/editor).
+# For tighter scoping set var.callout_service_account.
+
+locals {
+  callout_service_account = coalesce(
+    var.callout_service_account,
+    "${data.google_project.project.number}-compute@developer.gserviceaccount.com",
+  )
+
+  api_keys_all = {
+    anthropic  = var.anthropic_api_key
+    groq       = var.groq_api_key
+    openrouter = var.openrouter_api_key
+  }
+  active_providers = nonsensitive(toset([
+    for k, v in local.api_keys_all : k if v != ""
+  ]))
+
+  # Each provider here gets an Internet NEG + backend on the LB. The URL
+  # map matches `prefix=/v1/` + header `x-v2-target-provider:<provider>` to
+  # pick the right backend. Vertex AI is below as a separate resource.
+  third_party_providers = {
+    anthropic  = "api.anthropic.com"
+    groq       = "api.groq.com"
+    openrouter = "openrouter.ai"
+  }
+}
+
+# ===================================================================
+# SECRET MANAGER — PROVIDER API KEYS
+# ===================================================================
+
+resource "google_secret_manager_secret" "api_keys" {
+  for_each  = local.active_providers
+  secret_id = "litellm-gateway-${each.key}-api-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "api_keys" {
+  for_each    = local.active_providers
+  secret      = google_secret_manager_secret.api_keys[each.key].id
+  secret_data = local.api_keys_all[each.key]
+}
+
+resource "google_secret_manager_secret_iam_member" "callout_accessor" {
+  for_each  = local.active_providers
+  secret_id = google_secret_manager_secret.api_keys[each.key].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${local.callout_service_account}"
+}
+
+# ===================================================================
+# CLOUD RUN — CALLOUT (Python ext_proc service)
+# ===================================================================
+
+resource "google_cloud_run_v2_service" "callout" {
+  name                = "litellm-gateway-callout"
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = local.callout_service_account
+
+    containers {
+      name  = "callout"
+      image = var.callout_image
+      ports {
+        name           = "h2c"
+        container_port = 8080
+      }
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "GCP_REGION"
+        value = var.region
+      }
+      dynamic "env" {
+        for_each = local.active_providers
+        content {
+          name = "${upper(env.key)}_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.api_keys[env.key].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+      startup_probe {
+        http_get {
+          path = "/"
+          port = 80
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 3
+      }
+      liveness_probe {
+        http_get {
+          path = "/"
+          port = 80
+        }
+        period_seconds = 10
+      }
+    }
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 10
+    }
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_secret_manager_secret_version.api_keys,
+    google_secret_manager_secret_iam_member.callout_accessor,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "callout_public_invoker" {
+  name     = google_cloud_run_v2_service.callout.name
+  location = google_cloud_run_v2_service.callout.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_compute_region_network_endpoint_group" "callout_neg" {
+  name                  = "litellm-gateway-callout-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+  cloud_run {
+    service = google_cloud_run_v2_service.callout.name
+  }
+}
+
+resource "google_compute_backend_service" "callout_backend" {
+  name                  = "litellm-gateway-callout-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTP2"
+  backend {
+    group = google_compute_region_network_endpoint_group.callout_neg.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+# ===================================================================
+# CLOUD RUN — UPSTREAM APPLICATION (non-LLM traffic, e.g., chat UI)
+# ===================================================================
+
+resource "google_cloud_run_v2_service" "upstream_app" {
+  name                = "litellm-gateway-upstream"
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = var.upstream_app_image
+      ports {
+        container_port = 8080
+      }
+    }
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 5
+    }
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "upstream_public_invoker" {
+  name     = google_cloud_run_v2_service.upstream_app.name
+  location = google_cloud_run_v2_service.upstream_app.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_compute_region_network_endpoint_group" "upstream_neg" {
+  name                  = "litellm-gateway-upstream-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+  cloud_run {
+    service = google_cloud_run_v2_service.upstream_app.name
+  }
+}
+
+resource "google_compute_backend_service" "upstream_backend" {
+  name                  = "litellm-gateway-upstream-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  backend {
+    group = google_compute_region_network_endpoint_group.upstream_neg.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+# ===================================================================
+# VERTEX AI BACKEND — GLOBAL INTERNET NEG
+# ===================================================================
+
+resource "google_compute_global_network_endpoint_group" "vertex_neg" {
+  name                  = "litellm-gateway-vertex-neg"
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+  default_port          = 443
+  depends_on            = [google_project_service.apis]
+}
+
+resource "google_compute_global_network_endpoint" "vertex_endpoint" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.vertex_neg.name
+  fqdn                          = "${var.region}-aiplatform.googleapis.com"
+  port                          = 443
+}
+
+resource "google_compute_backend_service" "vertex_backend" {
+  name                  = "litellm-gateway-vertex-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  timeout_sec           = 180
+  backend {
+    group           = google_compute_global_network_endpoint_group.vertex_neg.id
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  depends_on = [google_compute_global_network_endpoint.vertex_endpoint]
+}
+
+# ===================================================================
+# THIRD-PARTY PROVIDER BACKENDS — GLOBAL INTERNET NEGs
+# ===================================================================
+
+resource "google_compute_global_network_endpoint_group" "provider_neg" {
+  for_each              = local.third_party_providers
+  name                  = "litellm-gateway-${each.key}-neg"
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+  default_port          = 443
+  depends_on            = [google_project_service.apis]
+}
+
+resource "google_compute_global_network_endpoint" "provider_endpoint" {
+  for_each                      = local.third_party_providers
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.provider_neg[each.key].name
+  fqdn                          = each.value
+  port                          = 443
+}
+
+resource "google_compute_backend_service" "provider_backend" {
+  for_each              = local.third_party_providers
+  name                  = "litellm-gateway-${each.key}-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  timeout_sec           = 180
+  backend {
+    group           = google_compute_global_network_endpoint_group.provider_neg[each.key].id
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  depends_on = [google_compute_global_network_endpoint.provider_endpoint]
+}
+
+# ===================================================================
+# LOAD BALANCER — GLOBAL EXTERNAL APPLICATION LB
+# ===================================================================
+
+resource "google_compute_global_address" "lb_ip" {
+  name = "litellm-gateway-lb-ip"
+}
+
+resource "tls_private_key" "lb_key" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "lb_cert" {
+  private_key_pem = tls_private_key.lb_key.private_key_pem
+  subject {
+    common_name = "litellm-gateway.example.com"
+  }
+  validity_period_hours = 8760
+  allowed_uses          = ["server_auth"]
+}
+
+resource "google_compute_ssl_certificate" "lb_cert" {
+  name        = "litellm-gateway-cert"
+  private_key = tls_private_key.lb_key.private_key_pem
+  certificate = tls_self_signed_cert.lb_cert.cert_pem
+}
+
+# URL map: header-based routing — the URL map picks the right provider
+# backend by matching the client-supplied `x-v2-target-provider` header.
+# The Traffic Extension reads the body, transforms OpenAI → provider format,
+# and rewrites `:path` for the upstream call. It does NOT influence routing
+# (Traffic Extensions can't switch backends post-decision).
+#
+# So the rules are:
+#   /v1/* + x-v2-target-provider=anthropic   → Anthropic backend
+#   /v1/* + x-v2-target-provider=groq        → Groq backend
+#   /v1/* + x-v2-target-provider=openrouter  → OpenRouter backend
+#   /v1/*                                  → Vertex AI backend (default)
+#   anything else                          → upstream sample UI
+resource "google_compute_url_map" "url_map" {
+  name            = "litellm-gateway-url-map"
+  default_service = google_compute_backend_service.upstream_backend.id
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "llm"
+  }
+
+  path_matcher {
+    name            = "llm"
+    default_service = google_compute_backend_service.upstream_backend.id
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-v2-target-provider"
+          exact_match  = "anthropic"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["anthropic"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "api.anthropic.com"
+        }
+      }
+    }
+
+    route_rules {
+      priority = 2
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-v2-target-provider"
+          exact_match  = "groq"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["groq"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "api.groq.com"
+        }
+      }
+    }
+
+    route_rules {
+      priority = 3
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-v2-target-provider"
+          exact_match  = "openrouter"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["openrouter"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "openrouter.ai"
+        }
+      }
+    }
+
+    # Fallback for /v1/* with no header (or vertex_ai header) → Vertex AI.
+    route_rules {
+      priority = 4
+      match_rules {
+        prefix_match = "/v1/"
+      }
+      service = google_compute_backend_service.vertex_backend.id
+      route_action {
+        url_rewrite {
+          host_rewrite = "${var.region}-aiplatform.googleapis.com"
+        }
+      }
+    }
+  }
+}
+
+resource "google_compute_target_https_proxy" "https_proxy" {
+  name             = "litellm-gateway-https-proxy"
+  url_map          = google_compute_url_map.url_map.id
+  ssl_certificates = [google_compute_ssl_certificate.lb_cert.id]
+}
+
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "litellm-gateway-fwd-rule"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.https_proxy.id
+  ip_address            = google_compute_global_address.lb_ip.id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# ===================================================================
+# SERVICE EXTENSIONS — TRAFFIC EXTENSION
+# ===================================================================
+#
+# Traffic Extension on Global LB. The callout sees REQUEST_BODY and does:
+#   1. Body transform OpenAI → provider format (LiteLLM)
+#   2. :path rewrite to the provider-specific path (LiteLLM's get_complete_url)
+#   3. Auth header injection (Authorization for Vertex via ADC, x-api-key
+#      for Anthropic, etc. — all via LiteLLM's validate_environment)
+#
+# It does NOT influence routing. Routing was decided by the URL map based on
+# the client's x-v2-target-provider header.
+
+resource "google_network_services_lb_traffic_extension" "callout" {
+  name                  = "litellm-gateway-traffic-ext"
+  location              = "global"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  forwarding_rules = [
+    google_compute_global_forwarding_rule.forwarding_rule.self_link
+  ]
+  extension_chains {
+    name = "litellm-gateway-chain"
+    match_condition {
+      cel_expression = "request.path in ['/v1/chat/completions', '/v1/completions', '/v1/embeddings', '/v1/models', '/chat/completions', '/completions', '/embeddings']"
+    }
+    extensions {
+      name             = "litellm-gateway-callout"
+      service          = google_compute_backend_service.callout_backend.self_link
+      authority        = "litellm-gateway.example.com"
+      supported_events = ["REQUEST_HEADERS", "REQUEST_BODY", "RESPONSE_HEADERS", "RESPONSE_BODY"]
+      timeout          = "10s"
+    }
+  }
+  depends_on = [google_project_service.apis]
+}
+
+# ===================================================================
+# OUTPUTS
+# ===================================================================
+
+output "load_balancer_ip" {
+  description = "The external IP address of the load balancer."
+  value       = google_compute_global_address.lb_ip.address
+}
+
+output "callout_service_url" {
+  description = "The URL of the Python ext_proc callout Cloud Run service."
+  value       = google_cloud_run_v2_service.callout.uri
+}
+
+output "upstream_service_url" {
+  description = "The URL of the upstream application Cloud Run service."
+  value       = google_cloud_run_v2_service.upstream_app.uri
+}
+
+output "vertex_endpoint" {
+  description = "The Vertex AI FQDN this deployment forwards LLM requests to."
+  value       = "${var.region}-aiplatform.googleapis.com"
+}
+
+output "curl_test_command" {
+  description = "Example curl command to test the LiteLLM gateway through the load balancer."
+  value       = <<-EOT
+    # Vertex AI (no header needed — default)
+    curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{"model": "vertex_ai/gemini-2.5-flash", "messages": [{"role": "user", "content": "Hello"}]}'
+
+    # Anthropic / Groq / OpenRouter — set x-v2-target-provider header
+    curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "x-v2-target-provider: anthropic" \
+      -d '{"model": "anthropic/claude-haiku-4-5", "messages": [{"role": "user", "content": "Hello"}]}'
+  EOT
+}

--- a/callouts/python/extproc/example/litellm_gateway/deploy/terraform/terraform.tfvars.example
+++ b/callouts/python/extproc/example/litellm_gateway/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy this file to terraform.tfvars and fill in your values.
+
+project_id = "your-gcp-project-id"
+region     = "us-central1"
+
+# Container image — build and push using cloudbuild.yaml (Python callout).
+callout_image = "us-central1-docker.pkg.dev/your-project/litellm-gateway/callout:latest"
+
+# Upstream app image (receives non-LLM traffic).
+# Defaults to a "Hello, world!" image. Use the sample-ui image to serve the chat interface:
+# upstream_app_image = "us-central1-docker.pkg.dev/your-project/litellm-gateway/sample-ui:latest"
+
+# Email of the service account used by the callout Cloud Run service.
+# Must have roles/aiplatform.user so LiteLLM's ADC flow can mint Vertex AI tokens.
+# If empty, the project's default compute SA is used (has roles/editor).
+# callout_service_account = "litellm-gateway-sa@your-project.iam.gserviceaccount.com"
+
+# Provider API keys — only required for the providers you actually use.
+# These are written into Cloud Run env vars; LiteLLM reads them automatically.
+# anthropic_api_key  = "my-api-key"
+# groq_api_key       = "my-api-key"
+# openrouter_api_key = "my-api-key"

--- a/callouts/python/extproc/example/litellm_gateway/deploy/terraform/terraform.tfvars.example
+++ b/callouts/python/extproc/example/litellm_gateway/deploy/terraform/terraform.tfvars.example
@@ -17,7 +17,7 @@
 project_id = "your-gcp-project-id"
 region     = "us-central1"
 
-# Container image — build and push using cloudbuild.yaml (Python callout).
+# Container image. Build and push using cloudbuild.yaml (Python callout).
 callout_image = "us-central1-docker.pkg.dev/your-project/litellm-gateway/callout:latest"
 
 # Upstream app image (receives non-LLM traffic).
@@ -29,7 +29,7 @@ callout_image = "us-central1-docker.pkg.dev/your-project/litellm-gateway/callout
 # If empty, the project's default compute SA is used (has roles/editor).
 # callout_service_account = "litellm-gateway-sa@your-project.iam.gserviceaccount.com"
 
-# Provider API keys — only required for the providers you actually use.
+# Provider API keys. Only required for the providers you actually use.
 # These are written into Cloud Run env vars; LiteLLM reads them automatically.
 # anthropic_api_key  = "my-api-key"
 # groq_api_key       = "my-api-key"

--- a/callouts/python/extproc/example/litellm_gateway/deploy/terraform/variables.tf
+++ b/callouts/python/extproc/example/litellm_gateway/deploy/terraform/variables.tf
@@ -1,0 +1,62 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The Google Cloud project ID where the resources will be created."
+  type        = string
+}
+
+variable "region" {
+  description = "The Google Cloud region for the resources."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "callout_image" {
+  description = "The container image for the Python ext_proc callout service."
+  type        = string
+}
+
+variable "upstream_app_image" {
+  description = "The container image for the upstream application (receives non-LLM traffic)."
+  type        = string
+  default     = "gcr.io/google-samples/hello-app:1.0"
+}
+
+variable "callout_service_account" {
+  description = "Email of the service account used by the callout Cloud Run service. Must have roles/aiplatform.user so LiteLLM's ADC flow can mint Vertex AI bearer tokens. If empty, the project's default compute SA is used."
+  type        = string
+  default     = ""
+}
+
+variable "anthropic_api_key" {
+  description = "Anthropic API key. Picked up by LiteLLM when the request model starts with 'anthropic/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "groq_api_key" {
+  description = "Groq API key. Picked up by LiteLLM when the request model starts with 'groq/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "openrouter_api_key" {
+  description = "OpenRouter API key. Picked up by LiteLLM when the request model starts with 'openrouter/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/callouts/python/extproc/example/litellm_gateway/sample-ui/Dockerfile
+++ b/callouts/python/extproc/example/litellm_gateway/sample-ui/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 8080
+RUN sed -i 's/listen\s*80;/listen 8080;/' /etc/nginx/conf.d/default.conf

--- a/callouts/python/extproc/example/litellm_gateway/sample-ui/cloudbuild.yaml
+++ b/callouts/python/extproc/example/litellm_gateway/sample-ui/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/litellm-gateway/sample-ui:latest'
+      - '.'
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/litellm-gateway/sample-ui:latest'

--- a/callouts/python/extproc/example/litellm_gateway/sample-ui/index.html
+++ b/callouts/python/extproc/example/litellm_gateway/sample-ui/index.html
@@ -366,16 +366,17 @@
       const headers = { 'Content-Type': 'application/json' };
       const key = getApiKey();
       if (key) headers['Authorization'] = 'Bearer ' + key;
-      // Routing signal — the LB's URL map matches on this header to pick
-      // the correct provider backend. The provider is the first segment
-      // of the LiteLLM model id (e.g. anthropic/claude-... → anthropic).
+      // Routing signal: the LB's URL map prefix-matches on this header
+      // to pick the correct provider backend. The header value is the
+      // LiteLLM model id verbatim (e.g. anthropic/claude-...); the URL
+      // map matches the leading `<provider>/` segment.
       if (state.selectedModel) {
-        headers['x-v2-target-provider'] = state.selectedModel.split('/', 1)[0];
+        headers['x-model-id'] = state.selectedModel;
       }
       return headers;
     }
 
-    // Models are defined here rather than fetched from /v1/models — the Python
+    // Models are defined here rather than fetched from /v1/models. The Python
     // callout uses LiteLLM in-process so /v1/models is not implemented.
     // Each entry is a LiteLLM model id: <provider>/<model>. For OpenRouter
     // (an aggregator), the model id includes the upstream publisher prefix,

--- a/callouts/python/extproc/example/litellm_gateway/sample-ui/index.html
+++ b/callouts/python/extproc/example/litellm_gateway/sample-ui/index.html
@@ -1,0 +1,634 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2026 Google LLC.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LiteLLM Gateway Demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f0f2f5;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      background: #1a73e8;
+      color: white;
+      padding: 12px 20px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      flex: 1;
+    }
+
+    .header-controls label {
+      font-size: 13px;
+      font-weight: 500;
+    }
+
+    .header-controls select,
+    .header-controls input {
+      padding: 6px 10px;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      background: rgba(255,255,255,0.15);
+      color: white;
+      outline: none;
+    }
+
+    .header-controls select option { color: #333; background: white; }
+    .header-controls input::placeholder { color: rgba(255,255,255,0.5); }
+    .header-controls select:focus,
+    .header-controls input:focus { background: rgba(255,255,255,0.25); }
+
+    .status-badge {
+      font-size: 12px;
+      padding: 4px 10px;
+      border-radius: 12px;
+      font-weight: 500;
+      margin-left: auto;
+    }
+
+    .status-badge.connected { background: #34a853; }
+    .status-badge.error { background: #ea4335; }
+    .status-badge.loading { background: #fbbc04; color: #333; }
+
+    #chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .message {
+      max-width: 75%;
+      padding: 12px 16px;
+      border-radius: 16px;
+      font-size: 14px;
+      line-height: 1.6;
+      word-wrap: break-word;
+    }
+
+    .message.user {
+      align-self: flex-end;
+      background: #1a73e8;
+      color: white;
+      border-bottom-right-radius: 4px;
+      white-space: pre-wrap;
+    }
+
+    .message.assistant {
+      align-self: flex-start;
+      background: white;
+      color: #333;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+
+    .message.assistant h1,
+    .message.assistant h2,
+    .message.assistant h3 {
+      margin: 12px 0 6px 0;
+      font-weight: 600;
+    }
+    .message.assistant h1 { font-size: 1.3em; }
+    .message.assistant h2 { font-size: 1.15em; }
+    .message.assistant h3 { font-size: 1.05em; }
+    .message.assistant h1:first-child,
+    .message.assistant h2:first-child,
+    .message.assistant h3:first-child { margin-top: 0; }
+
+    .message.assistant p { margin: 8px 0; }
+    .message.assistant p:first-child { margin-top: 0; }
+    .message.assistant p:last-child { margin-bottom: 0; }
+
+    .message.assistant ul,
+    .message.assistant ol {
+      margin: 8px 0;
+      padding-left: 20px;
+    }
+
+    .message.assistant li { margin: 4px 0; }
+
+    .message.assistant code {
+      background: #f1f3f4;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+      font-family: 'Consolas', 'Monaco', monospace;
+    }
+
+    .message.assistant pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 12px 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 10px 0;
+      font-size: 0.85em;
+      line-height: 1.5;
+    }
+
+    .message.assistant pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+      font-size: inherit;
+    }
+
+    .message.assistant blockquote {
+      border-left: 3px solid #1a73e8;
+      padding: 4px 12px;
+      margin: 8px 0;
+      color: #555;
+      background: #f8f9fa;
+      border-radius: 0 6px 6px 0;
+    }
+
+    .message.assistant hr {
+      border: none;
+      border-top: 1px solid #e0e0e0;
+      margin: 12px 0;
+    }
+
+    .message.assistant strong { font-weight: 600; }
+    .message.assistant em { font-style: italic; }
+
+    .message.error {
+      align-self: flex-start;
+      background: #fce8e6;
+      color: #c5221f;
+      border-bottom-left-radius: 4px;
+      white-space: pre-wrap;
+    }
+
+    .message.thinking {
+      align-self: flex-start;
+      background: white;
+      color: #999;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+
+    .thinking-dots span {
+      animation: blink 1.4s infinite both;
+    }
+    .thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+    .thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+    @keyframes blink {
+      0%, 80%, 100% { opacity: 0.3; }
+      40% { opacity: 1; }
+    }
+
+    #resizer {
+      height: 6px;
+      background: #e0e0e0;
+      cursor: ns-resize;
+      flex-shrink: 0;
+      position: relative;
+      transition: background 0.15s;
+    }
+
+    #resizer:hover,
+    #resizer.active { background: #1a73e8; }
+
+    #resizer::after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 36px;
+      height: 3px;
+      border-radius: 2px;
+      background: rgba(0,0,0,0.2);
+    }
+
+    #resizer:hover::after,
+    #resizer.active::after { background: rgba(255,255,255,0.6); }
+
+    #chat-form {
+      padding: 12px 20px;
+      background: white;
+      display: flex;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    #user-input {
+      flex: 1;
+      height: 100%;
+      padding: 12px 16px;
+      border: 1px solid #ddd;
+      border-radius: 16px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: none;
+      outline: none;
+    }
+
+    #user-input:focus { border-color: #1a73e8; }
+
+    #send-button {
+      padding: 0 24px;
+      background: #1a73e8;
+      color: white;
+      border: none;
+      border-radius: 24px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    #send-button:hover { background: #1557b0; }
+    #send-button:disabled { background: #ccc; cursor: not-allowed; }
+
+    footer {
+      padding: 8px 20px;
+      background: #fafafa;
+      border-top: 1px solid #e0e0e0;
+      font-size: 12px;
+      color: #666;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .welcome {
+      text-align: center;
+      color: #999;
+      padding: 40px 20px;
+      font-size: 14px;
+    }
+
+    .welcome h2 {
+      font-size: 20px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>LiteLLM Gateway Demo</h1>
+    <div class="header-controls">
+      <label for="model-select">Model:</label>
+      <select id="model-select" data-testid="model-select" disabled>
+        <option value="">Loading models...</option>
+      </select>
+    </div>
+    <input id="api-key" data-testid="api-key" type="hidden" value="sk-test-master-key">
+    <span id="status" class="status-badge loading" data-testid="status">Connecting...</span>
+  </header>
+
+  <div id="chat-messages" data-testid="chat-messages">
+    <div class="welcome">
+      <h2>Welcome</h2>
+      <p>Select a model above and start chatting.</p>
+    </div>
+  </div>
+
+  <div id="resizer" data-testid="resizer"></div>
+
+  <form id="chat-form" style="height: 80px;">
+    <textarea id="user-input" data-testid="user-input" placeholder="Type a message..." disabled></textarea>
+    <button id="send-button" data-testid="send-button" type="submit" disabled>Send</button>
+  </form>
+
+  <footer>
+    <span id="metadata" data-testid="metadata">No messages yet</span>
+    <span>Powered by Service Extensions + LiteLLM</span>
+  </footer>
+
+  <script>
+    const state = {
+      apiBase: '',
+      apiKey: '',
+      messages: [],
+      selectedModel: '',
+      sending: false,
+    };
+
+    function getApiBase() {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('api')) return params.get('api').replace(/\/+$/, '');
+      if (window.LITELLM_API_BASE) return window.LITELLM_API_BASE.replace(/\/+$/, '');
+      // When served from the same domain (e.g. behind the ALB), use relative paths.
+      // Fall back to localhost:4000 for local dev with docker-compose.
+      if (window.location.protocol === 'https:') return '';
+      return 'http://localhost:4000';
+    }
+
+    function getApiKey() {
+      return document.getElementById('api-key').value.trim();
+    }
+
+    function buildHeaders() {
+      const headers = { 'Content-Type': 'application/json' };
+      const key = getApiKey();
+      if (key) headers['Authorization'] = 'Bearer ' + key;
+      // Routing signal — the LB's URL map matches on this header to pick
+      // the correct provider backend. The provider is the first segment
+      // of the LiteLLM model id (e.g. anthropic/claude-... → anthropic).
+      if (state.selectedModel) {
+        headers['x-v2-target-provider'] = state.selectedModel.split('/', 1)[0];
+      }
+      return headers;
+    }
+
+    // Models are defined here rather than fetched from /v1/models — the Python
+    // callout uses LiteLLM in-process so /v1/models is not implemented.
+    // Each entry is a LiteLLM model id: <provider>/<model>. For OpenRouter
+    // (an aggregator), the model id includes the upstream publisher prefix,
+    // e.g. openrouter/openai/gpt-oss-20b:free.
+    var AVAILABLE_MODELS = [
+      'vertex_ai/gemini-2.5-flash',
+      'vertex_ai/gemini-2.5-pro',
+      'anthropic/claude-haiku-4-5',
+      'groq/compound-beta',
+      'openrouter/openai/gpt-oss-20b:free',
+    ];
+
+    function fetchModels() {
+      const statusEl = document.getElementById('status');
+      const selectEl = document.getElementById('model-select');
+
+      selectEl.innerHTML = '';
+      AVAILABLE_MODELS.forEach(function(id) {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = id;
+        selectEl.appendChild(opt);
+      });
+
+      state.selectedModel = AVAILABLE_MODELS[0];
+      selectEl.disabled = false;
+      document.getElementById('user-input').disabled = false;
+      document.getElementById('send-button').disabled = false;
+      statusEl.textContent = 'Connected';
+      statusEl.className = 'status-badge connected';
+    }
+
+    // Lightweight markdown to HTML converter.
+    function markdownToHtml(md) {
+      // Escape HTML entities first.
+      var html = md
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
+      // Fenced code blocks: ```lang\n...\n```
+      html = html.replace(/```(\w*)\n([\s\S]*?)```/g, function(_, lang, code) {
+        return '<pre><code>' + code.replace(/\n$/, '') + '</code></pre>';
+      });
+
+      // Inline code: `...`
+      html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+      // Headings: ### ... (process line by line).
+      html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+      html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+      html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+      // Horizontal rules: --- or ***
+      html = html.replace(/^(-{3,}|\*{3,})$/gm, '<hr>');
+
+      // Blockquotes: > ...
+      html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+
+      // Bold: **...**
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+
+      // Italic: *...*
+      html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+      // Unordered lists: convert consecutive "* " or "- " lines.
+      html = html.replace(/(^[\t ]*[*\-] .+$(\n|$))+/gm, function(block) {
+        var items = block.trim().split('\n').map(function(line) {
+          return '<li>' + line.replace(/^[\t ]*[*\-] /, '') + '</li>';
+        }).join('');
+        return '<ul>' + items + '</ul>';
+      });
+
+      // Ordered lists: consecutive "1. " lines.
+      html = html.replace(/(^\d+\. .+$(\n|$))+/gm, function(block) {
+        var items = block.trim().split('\n').map(function(line) {
+          return '<li>' + line.replace(/^\d+\. /, '') + '</li>';
+        }).join('');
+        return '<ol>' + items + '</ol>';
+      });
+
+      // Paragraphs: double newlines become paragraph breaks.
+      // Split on double newlines, wrap non-tag content in <p>.
+      html = html.split(/\n{2,}/).map(function(block) {
+        block = block.trim();
+        if (!block) return '';
+        // Don't wrap blocks that already start with a block-level tag.
+        if (/^<(h[1-3]|pre|ul|ol|blockquote|hr|p)/.test(block)) return block;
+        return '<p>' + block.replace(/\n/g, '<br>') + '</p>';
+      }).join('\n');
+
+      return html;
+    }
+
+    function renderMessage(role, content) {
+      const container = document.getElementById('chat-messages');
+      // Remove welcome message on first interaction.
+      const welcome = container.querySelector('.welcome');
+      if (welcome) welcome.remove();
+
+      const div = document.createElement('div');
+      div.className = 'message ' + role;
+      div.setAttribute('data-testid', 'message-' + role);
+
+      if (role === 'assistant') {
+        div.innerHTML = markdownToHtml(content);
+      } else {
+        div.textContent = content;
+      }
+
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+      return div;
+    }
+
+    function showThinking() {
+      const container = document.getElementById('chat-messages');
+      const div = document.createElement('div');
+      div.className = 'message thinking';
+      div.id = 'thinking-indicator';
+      div.innerHTML = '<span class="thinking-dots"><span>.</span><span>.</span><span>.</span></span>';
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+    }
+
+    function hideThinking() {
+      const el = document.getElementById('thinking-indicator');
+      if (el) el.remove();
+    }
+
+    function updateMetadata(usage, latencyMs, model) {
+      const el = document.getElementById('metadata');
+      const parts = ['Model: ' + model];
+      if (usage) {
+        parts.push(
+          'Tokens: ' + (usage.prompt_tokens || 0) + ' in / ' +
+          (usage.completion_tokens || 0) + ' out / ' +
+          (usage.total_tokens || 0) + ' total'
+        );
+      }
+      parts.push('Latency: ' + latencyMs + 'ms');
+      el.textContent = parts.join('  |  ');
+    }
+
+    async function sendMessage(userText) {
+      if (state.sending || !userText.trim()) return;
+      state.sending = true;
+
+      const input = document.getElementById('user-input');
+      const button = document.getElementById('send-button');
+      input.disabled = true;
+      button.disabled = true;
+
+      state.messages.push({ role: 'user', content: userText.trim() });
+      renderMessage('user', userText.trim());
+      showThinking();
+
+      const startTime = performance.now();
+
+      try {
+        const resp = await fetch(state.apiBase + '/v1/chat/completions', {
+          method: 'POST',
+          headers: buildHeaders(),
+          body: JSON.stringify({
+            model: state.selectedModel,
+            messages: state.messages,
+            stream: false,
+          }),
+        });
+
+        const latencyMs = Math.round(performance.now() - startTime);
+        hideThinking();
+
+        if (!resp.ok) {
+          const errBody = await resp.text();
+          throw new Error('HTTP ' + resp.status + ': ' + errBody);
+        }
+
+        const data = await resp.json();
+        if (!data.choices || !data.choices[0]) {
+          throw new Error('Unexpected response: ' + JSON.stringify(data).substring(0, 600));
+        }
+        const assistantContent = data.choices[0].message.content;
+
+        state.messages.push({ role: 'assistant', content: assistantContent });
+        renderMessage('assistant', assistantContent);
+        updateMetadata(data.usage, latencyMs, data.model || state.selectedModel);
+      } catch (err) {
+        hideThinking();
+        renderMessage('error', 'Error: ' + err.message);
+        // Remove the failed user message from history so conversation stays consistent.
+        state.messages.pop();
+      }
+
+      state.sending = false;
+      input.disabled = false;
+      button.disabled = false;
+      input.focus();
+    }
+
+    // --- Event Listeners ---
+
+    document.getElementById('chat-form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      var input = document.getElementById('user-input');
+      sendMessage(input.value);
+      input.value = '';
+    });
+
+    document.getElementById('user-input').addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        document.getElementById('chat-form').dispatchEvent(new Event('submit'));
+      }
+    });
+
+    document.getElementById('model-select').addEventListener('change', function() {
+      state.selectedModel = this.value;
+    });
+
+    // --- Resizer drag logic ---
+    (function() {
+      var resizer = document.getElementById('resizer');
+      var form = document.getElementById('chat-form');
+      var startY, startHeight;
+
+      resizer.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        startY = e.clientY;
+        startHeight = form.offsetHeight;
+        resizer.classList.add('active');
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+      });
+
+      function onMouseMove(e) {
+        var delta = startY - e.clientY;
+        var newHeight = Math.min(Math.max(startHeight + delta, 60), window.innerHeight * 0.5);
+        form.style.height = newHeight + 'px';
+      }
+
+      function onMouseUp() {
+        resizer.classList.remove('active');
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      }
+    })();
+
+    // --- Init ---
+
+    state.apiBase = getApiBase();
+    state.apiKey = getApiKey();
+    fetchModels();
+  </script>
+</body>
+</html>

--- a/callouts/python/extproc/example/litellm_gateway/service_callout_example.py
+++ b/callouts/python/extproc/example/litellm_gateway/service_callout_example.py
@@ -1,0 +1,663 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LiteLLM Gateway callout — pure ext_proc adapter.
+
+The callout is intentionally thin: it inspects the path, hands the OpenAI body
+to LiteLLM for translation (auth, body transform, target URL), and applies the
+result as ext_proc header + body mutations. The Cloud Load Balancer then
+forwards the rewritten request to the provider via an Internet NEG backend.
+
+Routing model: the LB's URL map picks the provider backend from the client's
+`x-v2-target-provider` header — *before* this callout fires. GCP Service
+Extensions don't allow body-based routing on a single LB (route extensions
+can't read the body, traffic extensions can't change the backend), so the
+header is the routing signal. Once the LB has picked the right backend, this
+traffic-extension callout transforms the body and headers in flight.
+
+LiteLLM owns:
+  * provider detection (`litellm.get_llm_provider`)
+  * OpenAI -> provider request body transform
+  * auth (ADC for Vertex AI via Cloud Run service identity, env-var API keys
+    for Anthropic / Groq / OpenRouter / etc.)
+  * provider response -> OpenAI ModelResponse transform
+  * SSE chunk parsing for streaming responses
+
+The callout owns:
+  * Envoy ext_proc protobuf adapter
+  * :path / :authority / Authorization header rewriting on the upstream call
+  * Stamping `x-litellm-*` provenance headers for observability
+"""
+
+import datetime
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from grpc import ServicerContext
+
+import litellm
+from litellm import ModelResponse
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+from envoy.config.core.v3.base_pb2 import HeaderValue, HeaderValueOption
+from envoy.extensions.filters.http.ext_proc.v3.processing_mode_pb2 import ProcessingMode
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.type.v3.http_status_pb2 import StatusCode
+
+from extproc.service import callout_server
+from extproc.service import callout_tools
+
+
+# Provenance headers stamped on the forwarded request. Observability only —
+# they don't affect routing (the LB already routed on the client's
+# x-v2-target-provider header before this callout ran).
+HEADER_LITELLM_ROUTED = "x-litellm-routed"
+HEADER_LITELLM_PROVIDER = "x-litellm-provider"
+HEADER_LITELLM_MODEL = "x-litellm-model"
+HEADER_LITELLM_STREAMING = "x-litellm-streaming"
+
+# OpenAI-compatible paths the callout intercepts. Anything else is a no-op.
+LLM_ENDPOINTS = frozenset({
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/models",
+    "/chat/completions",
+    "/completions",
+    "/embeddings",
+})
+
+# Headers the callout manages itself — never copy these from LiteLLM's output.
+_MANAGED_HEADERS = frozenset({
+    "host", ":authority", ":path", "content-length", "content-type",
+})
+
+# Default API bases by provider. LiteLLM's BaseConfig.get_complete_url() raises
+# "api_base is required" when no base is supplied; the SDK normally resolves
+# this inside `litellm.completion()`. We do it ourselves since we drive the
+# config classes directly.
+#
+# Anthropic uses /v1/messages directly (not /v1/chat/completions like the
+# OpenAI-compatible providers), so we include the path in the base.
+_PROVIDER_API_BASE = {
+    "anthropic":  "https://api.anthropic.com/v1/messages",
+    "groq":       "https://api.groq.com/openai/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
+    "mistral":    "https://api.mistral.ai/v1",
+    "deepseek":   "https://api.deepseek.com",
+    "openai":     "https://api.openai.com/v1",
+}
+
+@dataclass
+class _StreamState:
+    is_llm: bool = False
+    is_streaming: bool = False
+    model: str = ""
+    provider: str = ""
+    request_body: dict = field(default_factory=dict)
+    body_buffer: bytearray = field(default_factory=bytearray)
+    sse_buffer: str = ""
+    stream_iterator: Any = None
+    stream_iterator_resolved: bool = False
+
+
+def _state(context: ServicerContext) -> _StreamState:
+    state = getattr(context, "_litellm_state", None)
+    if state is None:
+        state = _StreamState()
+        context._litellm_state = state
+    return state
+
+
+class LiteLLMGatewayCallout(callout_server.CalloutServer):
+    """Ext_proc callout that delegates all LLM work to LiteLLM."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.gcp_project = os.getenv("GCP_PROJECT_ID", "")
+        self.gcp_region = os.getenv("GCP_REGION", "us-central1")
+        if not self.gcp_project:
+            logging.warning(
+                "GCP_PROJECT_ID is unset; Vertex AI requests will fail.")
+
+    def process(self, callout, context):
+        """Set response_body_mode on the response_headers reply.
+
+        On the response_headers event we tell the LB how to deliver the
+        response body to us: STREAMED for SSE (so we can transform chunks
+        on the fly), BUFFERED for everything else (so the response body
+        arrives whole and we can run LiteLLM's transform_response over it).
+        """
+        resp = super().process(callout, context)
+        if resp.HasField("immediate_response"):
+            return resp
+        if callout.HasField("response_headers"):
+            state = _state(context)
+            mode = ProcessingMode()
+            mode.response_body_mode = (
+                ProcessingMode.STREAMED if state.is_streaming else ProcessingMode.BUFFERED
+            )
+            resp.mode_override.CopyFrom(mode)
+        return resp
+
+    # ------------------------------------------------------------------ phases
+
+    def on_request_headers(
+        self,
+        headers: service_pb2.HttpHeaders,
+        context: ServicerContext,
+    ) -> service_pb2.ProcessingResponse | None:
+        path, method = "", ""
+        for h in headers.headers.headers:
+            if h.key == ":path":
+                path = h.raw_value.decode("utf-8")
+            elif h.key == ":method":
+                method = h.raw_value.decode("utf-8")
+        logging.info("Request %s %s", method, path)
+
+        if path not in LLM_ENDPOINTS:
+            return None
+
+        state = _state(context)
+        state.is_llm = True
+
+        resp = service_pb2.ProcessingResponse()
+        resp.request_headers.response.header_mutation.set_headers.append(
+            HeaderValueOption(
+                header=HeaderValue(key=HEADER_LITELLM_ROUTED, raw_value=b"true")))
+
+        return resp
+
+    def on_request_body(
+        self,
+        body: service_pb2.HttpBody,
+        context: ServicerContext,
+    ) -> service_pb2.BodyResponse | service_pb2.ImmediateResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return None
+
+        raw = body.body
+        if not raw:
+            return service_pb2.BodyResponse()
+
+        try:
+            req_map = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logging.warning("Invalid JSON body: %s", e)
+            return callout_tools.header_immediate_response(StatusCode.BadRequest)
+
+        model = req_map.get("model")
+        if not isinstance(model, str) or not model:
+            logging.warning("Request missing 'model' field")
+            return callout_tools.header_immediate_response(StatusCode.BadRequest)
+
+        try:
+            api_base, headers_dict, body_dict, provider, model_name = (
+                self._build_provider_request(model, req_map)
+            )
+        except Exception:
+            logging.exception("LiteLLM request transformation failed")
+            return callout_tools.header_immediate_response(
+                StatusCode.InternalServerError)
+
+        state.model = model_name
+        state.provider = provider
+        state.is_streaming = bool(req_map.get("stream"))
+        state.request_body = req_map
+
+        new_body = json.dumps(body_dict).encode("utf-8")
+
+        parsed = urlsplit(api_base)
+        target_authority = parsed.netloc
+        target_path = parsed.path or "/"
+        if parsed.query:
+            target_path = f"{target_path}?{parsed.query}"
+
+        logging.info(
+            "Routing :authority=%s :path=%s (provider=%s, streaming=%s)",
+            target_authority, target_path, provider, state.is_streaming,
+        )
+
+        body_resp = service_pb2.BodyResponse()
+        body_resp.response.body_mutation.body = new_body
+
+        rewrites: list[tuple[str, str]] = [
+            (":path", target_path),
+            (":authority", target_authority),
+            ("host", target_authority),
+            ("content-type", "application/json"),
+            ("content-length", str(len(new_body))),
+            # Prevent gzip — the response transformation needs raw JSON bytes.
+            ("accept-encoding", "identity"),
+            # Some upstreams (Groq via Cloudflare) reject requests with no
+            # User-Agent (or a generic "Google-LB" UA) as bot traffic.
+            ("user-agent", "litellm-gateway/1.0"),
+            # Provenance markers — observability only, not routing.
+            (HEADER_LITELLM_PROVIDER, provider),
+            (HEADER_LITELLM_MODEL, model_name),
+            (HEADER_LITELLM_STREAMING, "true" if state.is_streaming else "false"),
+        ]
+        # Apply the auth + provider-specific headers LiteLLM computed
+        # (Authorization: Bearer <ADC token>, x-api-key, anthropic-version, …).
+        for k, v in headers_dict.items():
+            if k.lower() in _MANAGED_HEADERS:
+                continue
+            rewrites.append((k.lower(), str(v)))
+
+        for k, v in rewrites:
+            body_resp.response.header_mutation.set_headers.append(
+                HeaderValueOption(
+                    header=HeaderValue(key=k, raw_value=v.encode("utf-8")),
+                    append_action=HeaderValueOption.OVERWRITE_IF_EXISTS_OR_ADD,
+                ))
+
+        # We don't set clear_route_cache here. GCP traffic extensions can't
+        # switch backends after URL map evaluation — routing was already
+        # decided by the URL map's header_matches on x-v2-target-provider.
+        return body_resp
+
+    def on_response_headers(
+        self,
+        headers: service_pb2.HttpHeaders,
+        context: ServicerContext,
+    ) -> service_pb2.HeadersResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return service_pb2.HeadersResponse()
+        resp = service_pb2.HeadersResponse()
+        # Provider's Content-Length will be wrong after our body transform —
+        # drop it so Envoy switches to chunked transfer encoding.
+        resp.response.header_mutation.remove_headers.append("content-length")
+        return resp
+
+    def on_response_body(
+        self,
+        body: service_pb2.HttpBody,
+        context: ServicerContext,
+    ) -> service_pb2.BodyResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return None
+        if state.is_streaming:
+            return self._handle_streaming_chunk(
+                state, body.body or b"", bool(body.end_of_stream))
+        return self._handle_buffered_chunk(
+            state, body.body or b"", bool(body.end_of_stream))
+
+    # ------------------------------------------------------------- LiteLLM
+
+    def _build_provider_request(
+        self,
+        model: str,
+        req_map: dict,
+    ) -> tuple[str, dict, dict, str, str]:
+        """Drive LiteLLM provider config to produce (URL, headers, body)."""
+        model_name, provider, _, _ = litellm.get_llm_provider(model=model)
+
+        try:
+            provider_enum = LlmProviders(provider)
+        except ValueError as e:
+            raise RuntimeError(f"Unsupported LiteLLM provider: {provider}") from e
+
+        config = ProviderConfigManager.get_provider_chat_config(
+            model=model_name, provider=provider_enum)
+        if config is None:
+            raise RuntimeError(f"No LiteLLM config for provider: {provider}")
+
+        messages = req_map.get("messages", [])
+        is_streaming = bool(req_map.get("stream"))
+        optional_params = {
+            k: v for k, v in req_map.items()
+            if k not in {"model", "messages"}
+        }
+
+        litellm_params: dict = {}
+        is_vertex = provider in ("vertex_ai", "vertex_ai_beta")
+        if is_vertex:
+            # ADC token comes from the Cloud Run service identity at runtime.
+            litellm_params["vertex_project"] = self.gcp_project
+            litellm_params["vertex_location"] = self.gcp_region
+
+        default_api_base = (
+            f"https://{self.gcp_region}-aiplatform.googleapis.com"
+            if is_vertex else _PROVIDER_API_BASE.get(provider)
+        )
+
+        # API keys for non-Vertex providers come from env vars set by Cloud
+        # Run (Secret Manager-backed). LiteLLM's validate_environment doesn't
+        # always read them itself, so pass explicitly.
+        api_key = None
+        if not is_vertex:
+            api_key = (
+                os.getenv(f"{provider.upper()}_API_KEY")
+                or os.getenv(f"{provider.upper().replace('_AI', '')}_API_KEY")
+            )
+
+        headers = config.validate_environment(
+            api_key=api_key,
+            headers={},
+            model=model_name,
+            messages=messages,
+            optional_params=optional_params,
+            api_base=default_api_base,
+            litellm_params=litellm_params,
+        )
+
+        # Anthropic blocks requests that look browser-originated unless the
+        # caller acknowledges direct-browser access via this opt-in header.
+        # Required when the LB forwards traffic that originally came from
+        # a browser (e.g., the sample UI).
+        if provider == "anthropic":
+            headers["anthropic-dangerous-direct-browser-access"] = "true"
+
+        # Vertex AI's auth lives on the LLM *handler*, not the config: the
+        # config's validate_environment doesn't include the ADC bearer token.
+        # Call VertexBase directly to mint the token via ADC and inject it.
+        if is_vertex and "Authorization" not in headers and "authorization" not in headers:
+            from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+            vb = VertexBase()
+            token, _ = vb._ensure_access_token(
+                credentials=None,
+                project_id=self.gcp_project,
+                custom_llm_provider="vertex_ai",
+            )
+            headers["Authorization"] = f"Bearer {token}"
+
+        if is_vertex:
+            # VertexGeminiConfig doesn't override get_complete_url; build the
+            # generateContent URL via LiteLLM's internal helper. _get_vertex_url
+            # returns (full_url_with_suffix, suffix_only) — use only the first.
+            from litellm.llms.vertex_ai.common_utils import _get_vertex_url
+            api_base, _ = _get_vertex_url(
+                mode="chat",
+                model=model_name,
+                stream=is_streaming,
+                vertex_project=self.gcp_project,
+                vertex_location=self.gcp_region,
+                vertex_api_version="v1",
+            )
+        else:
+            api_base = config.get_complete_url(
+                api_base=default_api_base,
+                api_key=None,
+                model=model_name,
+                optional_params=optional_params,
+                stream=is_streaming,
+                litellm_params=litellm_params,
+            )
+
+        body_dict = self._transform_request_body(
+            config, provider, model_name, messages, optional_params,
+            litellm_params, headers, api_base,
+        )
+        return api_base, headers, body_dict, provider, model_name
+
+    @staticmethod
+    def _transform_request_body(
+        config: Any,
+        provider: str,
+        model_name: str,
+        messages: list,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+        api_base: str,
+    ) -> dict:
+        """Call the provider config's body transform.
+
+        Vertex Gemini's `transform_request` raises NotImplementedError because
+        LiteLLM puts that provider's body construction on the handler, not the
+        config — its sync transform isn't exposed publicly. We fall back to a
+        minimal OpenAI→generateContent transform for that one provider.
+        """
+        try:
+            return config.transform_request(
+                model=model_name,
+                messages=messages,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+                headers=headers,
+            )
+        except NotImplementedError:
+            if provider not in ("vertex_ai", "vertex_ai_beta"):
+                raise
+            return _vertex_gemini_body({
+                "messages": messages,
+                **optional_params,
+            })
+
+    def _handle_buffered_chunk(
+        self,
+        state: _StreamState,
+        raw: bytes,
+        end_of_stream: bool,
+    ) -> service_pb2.BodyResponse:
+        state.body_buffer.extend(raw)
+        body_resp = service_pb2.BodyResponse()
+        if not end_of_stream:
+            # Suppress intermediate chunks; we emit the full transformed body
+            # once upstream finishes.
+            body_resp.response.body_mutation.body = b""
+            return body_resp
+        try:
+            openai_dict = self._transform_response_to_openai(
+                state, bytes(state.body_buffer))
+            body_resp.response.body_mutation.body = json.dumps(
+                openai_dict).encode("utf-8")
+        except Exception:
+            logging.exception(
+                "Response transformation failed; passing through raw body")
+            body_resp.response.body_mutation.body = bytes(state.body_buffer)
+        return body_resp
+
+    def _transform_response_to_openai(
+        self,
+        state: _StreamState,
+        raw_bytes: bytes,
+    ) -> dict:
+        """Run the provider response through LiteLLM's response transformer."""
+        try:
+            provider_enum = LlmProviders(state.provider)
+        except ValueError:
+            return json.loads(raw_bytes)
+
+        config = ProviderConfigManager.get_provider_chat_config(
+            model=state.model, provider=provider_enum)
+        if config is None:
+            return json.loads(raw_bytes)
+
+        fake_response = httpx.Response(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            content=raw_bytes,
+            request=httpx.Request("POST", "https://upstream.invalid"),
+        )
+        result = config.transform_response(
+            model=state.model,
+            raw_response=fake_response,
+            model_response=ModelResponse(),
+            logging_obj=self._stub_logging(state),
+            request_data=state.request_body,
+            messages=state.request_body.get("messages", []),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        return result.model_dump()
+
+    def _handle_streaming_chunk(
+        self,
+        state: _StreamState,
+        raw: bytes,
+        end_of_stream: bool,
+    ) -> service_pb2.BodyResponse:
+        """Transform provider SSE chunks to OpenAI SSE chunks via LiteLLM."""
+        iterator = self._stream_iterator(state)
+        if iterator is None:
+            # Provider returns OpenAI-format SSE already — pass-through.
+            body_resp = service_pb2.BodyResponse()
+            body_resp.response.body_mutation.body = raw
+            return body_resp
+
+        # Normalize CRLF to LF; SSE events are delimited by `\n\n`.
+        state.sse_buffer += raw.decode("utf-8", errors="replace").replace("\r\n", "\n")
+        out = bytearray()
+        while "\n\n" in state.sse_buffer:
+            event, _, rest = state.sse_buffer.partition("\n\n")
+            state.sse_buffer = rest
+            data = _extract_sse_data(event)
+            if data is None or data == "[DONE]":
+                continue
+            try:
+                chunk_dict = json.loads(data)
+            except json.JSONDecodeError:
+                logging.debug("Discarding non-JSON SSE event: %r", data[:200])
+                continue
+            try:
+                openai_chunk = iterator.chunk_parser(chunk_dict)
+                payload = openai_chunk.model_dump() if hasattr(
+                    openai_chunk, "model_dump") else openai_chunk
+                out.extend(b"data: ")
+                out.extend(json.dumps(payload).encode("utf-8"))
+                out.extend(b"\n\n")
+            except Exception:
+                logging.exception("Streaming chunk parser failed; skipping")
+        if end_of_stream:
+            out.extend(b"data: [DONE]\n\n")
+        body_resp = service_pb2.BodyResponse()
+        body_resp.response.body_mutation.body = bytes(out)
+        return body_resp
+
+    def _stream_iterator(self, state: _StreamState):
+        """Build a per-stream provider chunk iterator.
+
+        Returns None for OpenAI-compatible providers (chunks pass through
+        unchanged) and as a graceful fallback when the provider's iterator
+        constructor signature can't be satisfied. The iterator instance is
+        cached on state because per-chunk parsing maintains internal state
+        (tool_index, content_blocks, etc.).
+        """
+        if state.stream_iterator_resolved:
+            return state.stream_iterator
+        state.stream_iterator_resolved = True
+        if state.provider in ("vertex_ai", "vertex_ai_beta"):
+            from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+                ModelResponseIterator,
+            )
+        elif state.provider == "anthropic":
+            from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+        else:
+            return None
+        # The iterator constructor signature drifts across LiteLLM versions —
+        # try the known shapes, then fall back to pass-through streaming.
+        logging_obj = self._stub_logging(state)
+        for kwargs in (
+            {"streaming_response": iter([]), "sync_stream": True, "json_mode": False},
+            {"streaming_response": iter([]), "sync_stream": True, "logging_obj": logging_obj},
+            {"streaming_response": iter([]), "sync_stream": True},
+        ):
+            try:
+                state.stream_iterator = ModelResponseIterator(**kwargs)
+                return state.stream_iterator
+            except TypeError:
+                continue
+        logging.warning(
+            "Could not construct a streaming chunk iterator for provider %r; "
+            "streaming responses will pass through in provider format.",
+            state.provider,
+        )
+        return None
+
+    @staticmethod
+    def _stub_logging(state: _StreamState) -> LiteLLMLogging:
+        """A no-op LiteLLM Logging object usable by provider transformers."""
+        obj = LiteLLMLogging(
+            model=state.model or "unknown",
+            messages=state.request_body.get("messages", []),
+            stream=state.is_streaming,
+            call_type="completion",
+            start_time=datetime.datetime.now(),
+            litellm_call_id="ext-proc-stub",
+            function_id="ext-proc-stub",
+        )
+        if not hasattr(obj, "optional_params"):
+            obj.optional_params = {}
+        return obj
+
+
+def _vertex_gemini_body(req_map: dict) -> dict:
+    """OpenAI chat-completions body → Vertex AI generateContent body.
+
+    Used as a fallback because LiteLLM's VertexGeminiConfig doesn't expose a
+    sync `transform_request` (only async). All other providers go through
+    LiteLLM's standard config.transform_request flow.
+    """
+    contents: list[dict] = []
+    system_parts: list[dict] = []
+    for msg in req_map.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        text = content if isinstance(content, str) else json.dumps(content)
+        if role == "system":
+            system_parts.append({"text": text})
+        else:
+            vertex_role = "model" if role == "assistant" else "user"
+            contents.append({"role": vertex_role, "parts": [{"text": text}]})
+    body: dict = {"contents": contents}
+    if system_parts:
+        body["systemInstruction"] = {"parts": system_parts}
+    gen_cfg: dict = {}
+    for src, dst in (
+        ("temperature", "temperature"),
+        ("top_p", "topP"),
+        ("top_k", "topK"),
+        ("max_tokens", "maxOutputTokens"),
+        ("max_completion_tokens", "maxOutputTokens"),
+        ("stop", "stopSequences"),
+        ("presence_penalty", "presencePenalty"),
+        ("frequency_penalty", "frequencyPenalty"),
+    ):
+        if src in req_map and req_map[src] is not None:
+            gen_cfg[dst] = req_map[src]
+    if gen_cfg:
+        body["generationConfig"] = gen_cfg
+    return body
+
+
+def _extract_sse_data(event: str) -> str | None:
+    """Extract concatenated `data:` lines from a single SSE event block.
+
+    SSE events can contain `event:`, `id:`, and `:comment` lines that we ignore.
+    Returns None if the event has no data line.
+    """
+    parts: list[str] = []
+    for line in event.split("\n"):
+        if line.startswith("data:"):
+            parts.append(line[len("data:"):].lstrip())
+    return "\n".join(parts) if parts else None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    LiteLLMGatewayCallout(disable_tls=True).run()

--- a/callouts/python/extproc/example/litellm_gateway/service_callout_example.py
+++ b/callouts/python/extproc/example/litellm_gateway/service_callout_example.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""LiteLLM Gateway callout — pure ext_proc adapter.
+"""LiteLLM Gateway callout: a pure ext_proc adapter.
 
 The callout is intentionally thin: it inspects the path, hands the OpenAI body
 to LiteLLM for translation (auth, body transform, target URL), and applies the
@@ -20,7 +20,8 @@ result as ext_proc header + body mutations. The Cloud Load Balancer then
 forwards the rewritten request to the provider via an Internet NEG backend.
 
 Routing model: the LB's URL map picks the provider backend from the client's
-`x-v2-target-provider` header — *before* this callout fires. GCP Service
+`x-model-id` header (prefix-matched on the LiteLLM model id),
+*before* this callout fires. GCP Service
 Extensions don't allow body-based routing on a single LB (route extensions
 can't read the body, traffic extensions can't change the backend), so the
 header is the routing signal. Once the LB has picked the right backend, this
@@ -45,7 +46,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import urlsplit
 
 import httpx
@@ -66,9 +67,9 @@ from extproc.service import callout_server
 from extproc.service import callout_tools
 
 
-# Provenance headers stamped on the forwarded request. Observability only —
+# Provenance headers stamped on the forwarded request. Observability only;
 # they don't affect routing (the LB already routed on the client's
-# x-v2-target-provider header before this callout ran).
+# x-model-id header before this callout ran).
 HEADER_LITELLM_ROUTED = "x-litellm-routed"
 HEADER_LITELLM_PROVIDER = "x-litellm-provider"
 HEADER_LITELLM_MODEL = "x-litellm-model"
@@ -85,7 +86,7 @@ LLM_ENDPOINTS = frozenset({
     "/embeddings",
 })
 
-# Headers the callout manages itself — never copy these from LiteLLM's output.
+# Headers the callout manages itself; never copy these from LiteLLM's output.
 _MANAGED_HEADERS = frozenset({
     "host", ":authority", ":path", "content-length", "content-type",
 })
@@ -101,10 +102,14 @@ _PROVIDER_API_BASE = {
     "anthropic":  "https://api.anthropic.com/v1/messages",
     "groq":       "https://api.groq.com/openai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
-    "mistral":    "https://api.mistral.ai/v1",
-    "deepseek":   "https://api.deepseek.com",
-    "openai":     "https://api.openai.com/v1",
 }
+
+class ProviderRequest(NamedTuple):
+    api_base_url: str
+    headers: dict[str, str]
+    body: dict[str, Any]
+    provider: str
+    model: str
 
 @dataclass
 class _StreamState:
@@ -138,7 +143,11 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             logging.warning(
                 "GCP_PROJECT_ID is unset; Vertex AI requests will fail.")
 
-    def process(self, callout, context):
+    def process(
+        self,
+        callout: service_pb2.ProcessingRequest,
+        context: ServicerContext,
+    ) -> service_pb2.ProcessingResponse:
         """Set response_body_mode on the response_headers reply.
 
         On the response_headers event we tell the LB how to deliver the
@@ -191,12 +200,20 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         body: service_pb2.HttpBody,
         context: ServicerContext,
     ) -> service_pb2.BodyResponse | service_pb2.ImmediateResponse | None:
+        # Assumes BUFFERED request body mode: the traffic extension does not
+        # set a streamed request body mode, so the load balancer delivers the
+        # whole request body in a single REQUEST_BODY message. We rely on that
+        # to `json.loads(body.body)` and transform the payload in one pass.
+        # If the request body were streamed, this method would receive partial
+        # chunks and the JSON parse below would fail on all but the last.
         state = _state(context)
         if not state.is_llm:
             return None
 
         raw = body.body
         if not raw:
+            logging.warning(
+                "Empty request body on LLM endpoint; expected a JSON payload.")
             return service_pb2.BodyResponse()
 
         try:
@@ -211,30 +228,28 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             return callout_tools.header_immediate_response(StatusCode.BadRequest)
 
         try:
-            api_base, headers_dict, body_dict, provider, model_name = (
-                self._build_provider_request(model, req_map)
-            )
+            pr = self._build_provider_request(model, req_map)
         except Exception:
             logging.exception("LiteLLM request transformation failed")
             return callout_tools.header_immediate_response(
                 StatusCode.InternalServerError)
 
-        state.model = model_name
-        state.provider = provider
+        state.model = pr.model
+        state.provider = pr.provider
         state.is_streaming = bool(req_map.get("stream"))
         state.request_body = req_map
 
-        new_body = json.dumps(body_dict).encode("utf-8")
+        new_body = json.dumps(pr.body).encode("utf-8")
 
-        parsed = urlsplit(api_base)
-        target_authority = parsed.netloc
-        target_path = parsed.path or "/"
-        if parsed.query:
-            target_path = f"{target_path}?{parsed.query}"
+        parsed_url = urlsplit(pr.api_base_url)
+        target_authority = parsed_url.netloc
+        target_path = parsed_url.path or "/"
+        if parsed_url.query:
+            target_path = f"{target_path}?{parsed_url.query}"
 
         logging.info(
             "Routing :authority=%s :path=%s (provider=%s, streaming=%s)",
-            target_authority, target_path, provider, state.is_streaming,
+            target_authority, target_path, pr.provider, state.is_streaming,
         )
 
         body_resp = service_pb2.BodyResponse()
@@ -246,22 +261,22 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             ("host", target_authority),
             ("content-type", "application/json"),
             ("content-length", str(len(new_body))),
-            # Prevent gzip — the response transformation needs raw JSON bytes.
+            # Prevent gzip so the response transform sees raw JSON bytes.
             ("accept-encoding", "identity"),
             # Some upstreams (Groq via Cloudflare) reject requests with no
             # User-Agent (or a generic "Google-LB" UA) as bot traffic.
             ("user-agent", "litellm-gateway/1.0"),
-            # Provenance markers — observability only, not routing.
-            (HEADER_LITELLM_PROVIDER, provider),
-            (HEADER_LITELLM_MODEL, model_name),
+            # Provenance markers (observability only, not routing).
+            (HEADER_LITELLM_PROVIDER, pr.provider),
+            (HEADER_LITELLM_MODEL, pr.model),
             (HEADER_LITELLM_STREAMING, "true" if state.is_streaming else "false"),
         ]
         # Apply the auth + provider-specific headers LiteLLM computed
         # (Authorization: Bearer <ADC token>, x-api-key, anthropic-version, …).
-        for k, v in headers_dict.items():
+        for k, v in pr.headers.items():
             if k.lower() in _MANAGED_HEADERS:
                 continue
-            rewrites.append((k.lower(), str(v)))
+            rewrites.append((k.lower(), v))
 
         for k, v in rewrites:
             body_resp.response.header_mutation.set_headers.append(
@@ -271,8 +286,8 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
                 ))
 
         # We don't set clear_route_cache here. GCP traffic extensions can't
-        # switch backends after URL map evaluation — routing was already
-        # decided by the URL map's header_matches on x-v2-target-provider.
+        # switch backends after URL map evaluation; routing was already
+        # decided by the URL map's header_matches on x-model-id.
         return body_resp
 
     def on_response_headers(
@@ -284,8 +299,8 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         if not state.is_llm:
             return service_pb2.HeadersResponse()
         resp = service_pb2.HeadersResponse()
-        # Provider's Content-Length will be wrong after our body transform —
-        # drop it so Envoy switches to chunked transfer encoding.
+        # Provider's Content-Length will be wrong after our body transform.
+        # Drop it so Envoy switches to chunked transfer encoding.
         resp.response.header_mutation.remove_headers.append("content-length")
         return resp
 
@@ -299,9 +314,9 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             return None
         if state.is_streaming:
             return self._handle_streaming_chunk(
-                state, body.body or b"", bool(body.end_of_stream))
+                state, body.body or b"", body.end_of_stream)
         return self._handle_buffered_chunk(
-            state, body.body or b"", bool(body.end_of_stream))
+            state, body.body or b"", body.end_of_stream)
 
     # ------------------------------------------------------------- LiteLLM
 
@@ -309,8 +324,12 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         self,
         model: str,
         req_map: dict,
-    ) -> tuple[str, dict, dict, str, str]:
-        """Drive LiteLLM provider config to produce (URL, headers, body)."""
+    ) -> ProviderRequest:
+        """Drive LiteLLM provider config to produce the upstream request.
+
+        Returns a `ProviderRequest` carrying api_base_url, headers, body,
+        provider, and model.
+        """
         model_name, provider, _, _ = litellm.get_llm_provider(model=model)
 
         try:
@@ -333,11 +352,15 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         litellm_params: dict = {}
         is_vertex = provider in ("vertex_ai", "vertex_ai_beta")
         if is_vertex:
+            if not self.gcp_project:
+                logging.warning(
+                    "Vertex AI request received but GCP_PROJECT_ID is unset; "
+                    "downstream call will likely fail with a malformed URL.")
             # ADC token comes from the Cloud Run service identity at runtime.
             litellm_params["vertex_project"] = self.gcp_project
             litellm_params["vertex_location"] = self.gcp_region
 
-        default_api_base = (
+        default_api_base_url = (
             f"https://{self.gcp_region}-aiplatform.googleapis.com"
             if is_vertex else _PROVIDER_API_BASE.get(provider)
         )
@@ -358,7 +381,7 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             model=model_name,
             messages=messages,
             optional_params=optional_params,
-            api_base=default_api_base,
+            api_base=default_api_base_url,
             litellm_params=litellm_params,
         )
 
@@ -385,9 +408,9 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         if is_vertex:
             # VertexGeminiConfig doesn't override get_complete_url; build the
             # generateContent URL via LiteLLM's internal helper. _get_vertex_url
-            # returns (full_url_with_suffix, suffix_only) — use only the first.
+            # returns (full_url_with_suffix, suffix_only); use only the first.
             from litellm.llms.vertex_ai.common_utils import _get_vertex_url
-            api_base, _ = _get_vertex_url(
+            api_base_url, _ = _get_vertex_url(
                 mode="chat",
                 model=model_name,
                 stream=is_streaming,
@@ -396,8 +419,8 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
                 vertex_api_version="v1",
             )
         else:
-            api_base = config.get_complete_url(
-                api_base=default_api_base,
+            api_base_url = config.get_complete_url(
+                api_base=default_api_base_url,
                 api_key=None,
                 model=model_name,
                 optional_params=optional_params,
@@ -407,9 +430,15 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
 
         body_dict = self._transform_request_body(
             config, provider, model_name, messages, optional_params,
-            litellm_params, headers, api_base,
+            litellm_params, headers,
         )
-        return api_base, headers, body_dict, provider, model_name
+        return ProviderRequest(
+            api_base_url=api_base_url,
+            headers=headers,
+            body=body_dict,
+            provider=provider,
+            model=model_name,
+        )
 
     @staticmethod
     def _transform_request_body(
@@ -420,13 +449,12 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
-        api_base: str,
     ) -> dict:
         """Call the provider config's body transform.
 
         Vertex Gemini's `transform_request` raises NotImplementedError because
         LiteLLM puts that provider's body construction on the handler, not the
-        config — its sync transform isn't exposed publicly. We fall back to a
+        config, and its sync transform isn't exposed publicly. We fall back to a
         minimal OpenAI→generateContent transform for that one provider.
         """
         try:
@@ -513,7 +541,7 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
         """Transform provider SSE chunks to OpenAI SSE chunks via LiteLLM."""
         iterator = self._stream_iterator(state)
         if iterator is None:
-            # Provider returns OpenAI-format SSE already — pass-through.
+            # Provider returns OpenAI-format SSE already; pass it through.
             body_resp = service_pb2.BodyResponse()
             body_resp.response.body_mutation.body = raw
             return body_resp
@@ -567,7 +595,7 @@ class LiteLLMGatewayCallout(callout_server.CalloutServer):
             from litellm.llms.anthropic.chat.handler import ModelResponseIterator
         else:
             return None
-        # The iterator constructor signature drifts across LiteLLM versions —
+        # The iterator constructor signature drifts across LiteLLM versions;
         # try the known shapes, then fall back to pass-through streaming.
         logging_obj = self._stub_logging(state)
         for kwargs in (

--- a/callouts/python/extproc/tests/litellm_gateway_test.py
+++ b/callouts/python/extproc/tests/litellm_gateway_test.py
@@ -14,7 +14,7 @@
 
 """Unit tests for the LiteLLM Gateway Python callout.
 
-Pure unit tests — no gRPC server started, no network calls. Phase methods are
+Pure unit tests: no gRPC server started, no network calls. Phase methods are
 called directly with synthetic proto objects. Provider transformations that
 LiteLLM can do offline (Anthropic body transform, Vertex generateContent
 response transform) are exercised against the real LiteLLM library; the parts
@@ -36,6 +36,7 @@ from extproc.example.litellm_gateway.service_callout_example import (
     HEADER_LITELLM_ROUTED,
     HEADER_LITELLM_STREAMING,
     LiteLLMGatewayCallout,
+    ProviderRequest,
     _StreamState,
     _extract_sse_data,
     _state,
@@ -48,7 +49,7 @@ from extproc.example.litellm_gateway.service_callout_example import (
 # ---------------------------------------------------------------------------
 
 class _Ctx:
-    """Minimal ServicerContext substitute — supports attribute assignment."""
+    """Minimal ServicerContext substitute that supports attribute assignment."""
 
 
 def _http_headers(headers_dict: dict) -> service_pb2.HttpHeaders:
@@ -72,25 +73,35 @@ def _set_headers(response) -> dict:
 
 @pytest.fixture(scope="module")
 def svc():
-    """Callout instance — no server started, no real GCP credentials."""
+    """Callout instance with no server started and no real GCP credentials."""
     with patch.dict(os.environ, {
         "GCP_PROJECT_ID": "test-project",
         "GCP_REGION": "us-central1",
         "ANTHROPIC_API_KEY": "sk-ant-test",
     }):
-        yield LiteLLMGatewayCallout(disable_tls=True)
+        callout = LiteLLMGatewayCallout(
+            disable_tls=True,
+            plaintext_address=("0.0.0.0", 0),
+        )
+        try:
+            yield callout
+        finally:
+            if callout._callout_server is not None:
+                callout._callout_server.stop()
 
 
-# A canned (URL, headers, body, provider, model) tuple matching what
-# _build_provider_request would return for a Vertex Gemini request — used to
-# patch out the GCP-credential-dependent path.
-_VERTEX_PROVIDER_REQUEST = (
-    "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project"
-    "/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent",
-    {"Authorization": "Bearer fake-adc-token", "content-type": "application/json"},
-    {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
-    "vertex_ai",
-    "gemini-2.5-flash",
+# A canned ProviderRequest matching what `_build_provider_request` would
+# return for a Vertex Gemini call. Used to patch out the GCP-credential
+# dependent path (ADC token mint).
+_VERTEX_PROVIDER_REQUEST = ProviderRequest(
+    api_base_url=(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project"
+        "/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+    ),
+    headers={"Authorization": "Bearer fake-adc-token", "content-type": "application/json"},
+    body={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+    provider="vertex_ai",
+    model="gemini-2.5-flash",
 )
 
 
@@ -163,7 +174,7 @@ class TestVertexGeminiBody:
         out = _vertex_gemini_body({"messages": [
             {"role": "user", "content": [{"type": "text", "text": "hi"}]},
         ]})
-        # Falls back to json.dumps — the important thing is it doesn't crash.
+        # Falls back to json.dumps; the important thing is it doesn't crash.
         assert out["contents"][0]["parts"][0]["text"]
 
     def test_empty_messages(self):
@@ -314,7 +325,7 @@ class TestOnRequestBody:
         assert _set_headers(result)[HEADER_LITELLM_STREAMING] == "true"
 
     def test_anthropic_request_end_to_end(self, svc):
-        # Exercises the real LiteLLM AnthropicConfig path — no network needed.
+        # Exercises the real LiteLLM AnthropicConfig path; no network needed.
         ctx = _Ctx()
         _state(ctx).is_llm = True
         body = json.dumps({
@@ -476,6 +487,6 @@ class TestHandleStreamingChunk:
     def test_crlf_normalized(self, svc):
         # Vertex emits CRLF-delimited SSE; ensure we still split events.
         state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
-        # An empty/comment event with CRLF — should consume cleanly, no crash.
+        # An empty/comment event with CRLF; should consume cleanly, no crash.
         svc._handle_streaming_chunk(state, b": ping\r\n\r\n", end_of_stream=False)
         assert state.sse_buffer == ""

--- a/callouts/python/extproc/tests/litellm_gateway_test.py
+++ b/callouts/python/extproc/tests/litellm_gateway_test.py
@@ -1,0 +1,481 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the LiteLLM Gateway Python callout.
+
+Pure unit tests — no gRPC server started, no network calls. Phase methods are
+called directly with synthetic proto objects. Provider transformations that
+LiteLLM can do offline (Anthropic body transform, Vertex generateContent
+response transform) are exercised against the real LiteLLM library; the parts
+that need GCP credentials (Vertex ADC token minting) are patched out.
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from envoy.config.core.v3.base_pb2 import HeaderMap, HeaderValue
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+
+from extproc.example.litellm_gateway.service_callout_example import (
+    HEADER_LITELLM_MODEL,
+    HEADER_LITELLM_PROVIDER,
+    HEADER_LITELLM_ROUTED,
+    HEADER_LITELLM_STREAMING,
+    LiteLLMGatewayCallout,
+    _StreamState,
+    _extract_sse_data,
+    _state,
+    _vertex_gemini_body,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+class _Ctx:
+    """Minimal ServicerContext substitute — supports attribute assignment."""
+
+
+def _http_headers(headers_dict: dict) -> service_pb2.HttpHeaders:
+    hm = HeaderMap()
+    for k, v in headers_dict.items():
+        hm.headers.append(HeaderValue(key=k, raw_value=v.encode()))
+    return service_pb2.HttpHeaders(headers=hm)
+
+
+def _body(body_bytes: bytes, end_of_stream: bool = False) -> service_pb2.HttpBody:
+    return service_pb2.HttpBody(body=body_bytes, end_of_stream=end_of_stream)
+
+
+def _set_headers(response) -> dict:
+    """{key: decoded_value} from a BodyResponse / HeadersResponse mutation."""
+    return {
+        hvo.header.key: hvo.header.raw_value.decode()
+        for hvo in response.response.header_mutation.set_headers
+    }
+
+
+@pytest.fixture(scope="module")
+def svc():
+    """Callout instance — no server started, no real GCP credentials."""
+    with patch.dict(os.environ, {
+        "GCP_PROJECT_ID": "test-project",
+        "GCP_REGION": "us-central1",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }):
+        yield LiteLLMGatewayCallout(disable_tls=True)
+
+
+# A canned (URL, headers, body, provider, model) tuple matching what
+# _build_provider_request would return for a Vertex Gemini request — used to
+# patch out the GCP-credential-dependent path.
+_VERTEX_PROVIDER_REQUEST = (
+    "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project"
+    "/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent",
+    {"Authorization": "Bearer fake-adc-token", "content-type": "application/json"},
+    {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+    "vertex_ai",
+    "gemini-2.5-flash",
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_sse_data
+# ---------------------------------------------------------------------------
+
+class TestExtractSseData:
+    def test_simple(self):
+        assert _extract_sse_data('data: {"k":"v"}') == '{"k":"v"}'
+
+    def test_strips_leading_space(self):
+        assert _extract_sse_data("data:  hello") == "hello"
+
+    def test_no_data_line_returns_none(self):
+        assert _extract_sse_data("event: ping\nid: 1") is None
+
+    def test_done_sentinel(self):
+        assert _extract_sse_data("data: [DONE]") == "[DONE]"
+
+    def test_multiple_data_lines_concatenated(self):
+        assert _extract_sse_data("data: a\ndata: b") == "a\nb"
+
+    def test_ignores_comment_and_event_lines(self):
+        assert _extract_sse_data(": comment\nevent: x\ndata: payload") == "payload"
+
+
+# ---------------------------------------------------------------------------
+# _vertex_gemini_body  (OpenAI chat-completions → Vertex generateContent)
+# ---------------------------------------------------------------------------
+
+class TestVertexGeminiBody:
+    def test_basic_user_message(self):
+        out = _vertex_gemini_body({"messages": [{"role": "user", "content": "Hello"}]})
+        assert out["contents"] == [{"role": "user", "parts": [{"text": "Hello"}]}]
+        assert "systemInstruction" not in out
+
+    def test_system_message_becomes_instruction(self):
+        out = _vertex_gemini_body({"messages": [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]})
+        assert out["systemInstruction"] == {"parts": [{"text": "Be helpful."}]}
+        assert len(out["contents"]) == 1
+
+    def test_assistant_role_mapped_to_model(self):
+        out = _vertex_gemini_body({"messages": [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]})
+        assert out["contents"][1]["role"] == "model"
+
+    def test_generation_config_forwarded(self):
+        out = _vertex_gemini_body({
+            "messages": [{"role": "user", "content": "x"}],
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "top_p": 0.9,
+        })
+        cfg = out["generationConfig"]
+        assert cfg["temperature"] == 0.7
+        assert cfg["maxOutputTokens"] == 100
+        assert cfg["topP"] == 0.9
+
+    def test_no_gen_config_when_absent(self):
+        out = _vertex_gemini_body({"messages": [{"role": "user", "content": "hi"}]})
+        assert "generationConfig" not in out
+
+    def test_non_string_content_serialized(self):
+        out = _vertex_gemini_body({"messages": [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ]})
+        # Falls back to json.dumps — the important thing is it doesn't crash.
+        assert out["contents"][0]["parts"][0]["text"]
+
+    def test_empty_messages(self):
+        assert _vertex_gemini_body({"messages": []})["contents"] == []
+
+
+# ---------------------------------------------------------------------------
+# on_request_headers
+# ---------------------------------------------------------------------------
+
+class TestOnRequestHeaders:
+    def test_non_llm_path_returns_none(self, svc):
+        ctx = _Ctx()
+        assert svc.on_request_headers(
+            _http_headers({":path": "/healthz", ":method": "GET"}), ctx) is None
+
+    def test_non_llm_path_does_not_mark_state(self, svc):
+        ctx = _Ctx()
+        svc.on_request_headers(_http_headers({":path": "/static/app.js", ":method": "GET"}), ctx)
+        assert _state(ctx).is_llm is False
+
+    def test_llm_path_returns_processing_response(self, svc):
+        ctx = _Ctx()
+        result = svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions", ":method": "POST"}), ctx)
+        assert isinstance(result, service_pb2.ProcessingResponse)
+
+    def test_llm_path_sets_routed_header(self, svc):
+        ctx = _Ctx()
+        result = svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions", ":method": "POST"}), ctx)
+        hdrs = {
+            hvo.header.key: hvo.header.raw_value.decode()
+            for hvo in result.request_headers.response.header_mutation.set_headers
+        }
+        assert hdrs.get(HEADER_LITELLM_ROUTED) == "true"
+
+    def test_llm_path_marks_state(self, svc):
+        ctx = _Ctx()
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/embeddings", ":method": "POST"}), ctx)
+        assert _state(ctx).is_llm is True
+
+
+# ---------------------------------------------------------------------------
+# on_request_body
+# ---------------------------------------------------------------------------
+
+class TestOnRequestBody:
+    def test_not_llm_returns_none(self, svc):
+        ctx = _Ctx()
+        assert svc.on_request_body(_body(b'{"model":"x"}'), ctx) is None
+
+    def test_empty_body_returns_body_response(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        assert isinstance(svc.on_request_body(_body(b""), ctx), service_pb2.BodyResponse)
+
+    def test_invalid_json_returns_400(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        result = svc.on_request_body(_body(b"not-json"), ctx)
+        assert isinstance(result, service_pb2.ImmediateResponse)
+        assert result.status.code == 400
+
+    def test_missing_model_returns_400(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        result = svc.on_request_body(_body(b'{"messages":[]}'), ctx)
+        assert isinstance(result, service_pb2.ImmediateResponse)
+        assert result.status.code == 400
+
+    def test_litellm_transform_failure_returns_500(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({"model": "vertex_ai/gemini-2.5-flash", "messages": []}).encode()
+        with patch.object(svc, "_build_provider_request", side_effect=RuntimeError("boom")):
+            result = svc.on_request_body(_body(body), ctx)
+        assert isinstance(result, service_pb2.ImmediateResponse)
+        assert result.status.code == 500
+
+    def test_vertex_request_rewrites_path_authority_auth(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "vertex_ai/gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        with patch.object(svc, "_build_provider_request", return_value=_VERTEX_PROVIDER_REQUEST):
+            result = svc.on_request_body(_body(body), ctx)
+        assert isinstance(result, service_pb2.BodyResponse)
+        hdrs = _set_headers(result)
+        assert hdrs[":path"].startswith("/v1/projects/test-project")
+        assert hdrs[":path"].endswith(":generateContent")
+        assert hdrs[":authority"] == "us-central1-aiplatform.googleapis.com"
+        assert hdrs["host"] == "us-central1-aiplatform.googleapis.com"
+        assert hdrs["authorization"] == "Bearer fake-adc-token"
+
+    def test_provenance_headers_set(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "vertex_ai/gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        with patch.object(svc, "_build_provider_request", return_value=_VERTEX_PROVIDER_REQUEST):
+            result = svc.on_request_body(_body(body), ctx)
+        hdrs = _set_headers(result)
+        assert hdrs[HEADER_LITELLM_PROVIDER] == "vertex_ai"
+        assert hdrs[HEADER_LITELLM_MODEL] == "gemini-2.5-flash"
+        assert hdrs[HEADER_LITELLM_STREAMING] == "false"
+
+    def test_content_length_matches_new_body(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "vertex_ai/gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        with patch.object(svc, "_build_provider_request", return_value=_VERTEX_PROVIDER_REQUEST):
+            result = svc.on_request_body(_body(body), ctx)
+        hdrs = _set_headers(result)
+        assert hdrs["content-length"] == str(len(result.response.body_mutation.body))
+
+    def test_no_clear_route_cache(self, svc):
+        # Traffic extensions can't switch backends; we must not set this.
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "vertex_ai/gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        with patch.object(svc, "_build_provider_request", return_value=_VERTEX_PROVIDER_REQUEST):
+            result = svc.on_request_body(_body(body), ctx)
+        assert result.response.clear_route_cache is False
+
+    def test_streaming_flag_recorded(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "vertex_ai/gemini-2.5-flash",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        with patch.object(svc, "_build_provider_request", return_value=_VERTEX_PROVIDER_REQUEST):
+            result = svc.on_request_body(_body(body), ctx)
+        assert _state(ctx).is_streaming is True
+        assert _set_headers(result)[HEADER_LITELLM_STREAMING] == "true"
+
+    def test_anthropic_request_end_to_end(self, svc):
+        # Exercises the real LiteLLM AnthropicConfig path — no network needed.
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        body = json.dumps({
+            "model": "anthropic/claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 64,
+        }).encode()
+        result = svc.on_request_body(_body(body), ctx)
+        assert isinstance(result, service_pb2.BodyResponse)
+        hdrs = _set_headers(result)
+        assert hdrs[":authority"] == "api.anthropic.com"
+        assert hdrs[":path"] == "/v1/messages"
+        assert hdrs["x-api-key"] == "sk-ant-test"
+        assert "anthropic-version" in hdrs
+        assert hdrs["anthropic-dangerous-direct-browser-access"] == "true"
+        assert hdrs[HEADER_LITELLM_PROVIDER] == "anthropic"
+        # Body should be Anthropic Messages format. LiteLLM normalizes string
+        # content to the structured [{"type":"text","text":...}] form.
+        new_body = json.loads(result.response.body_mutation.body)
+        assert new_body["max_tokens"] == 64
+        msg = new_body["messages"][0]
+        assert msg["role"] == "user"
+        text = msg["content"] if isinstance(msg["content"], str) else msg["content"][0]["text"]
+        assert text == "hi"
+
+
+# ---------------------------------------------------------------------------
+# on_response_headers
+# ---------------------------------------------------------------------------
+
+class TestOnResponseHeaders:
+    def test_not_llm_returns_empty_headers_response(self, svc):
+        ctx = _Ctx()
+        result = svc.on_response_headers(_http_headers({"content-type": "text/plain"}), ctx)
+        assert isinstance(result, service_pb2.HeadersResponse)
+        assert not result.response.header_mutation.remove_headers
+
+    def test_llm_removes_content_length(self, svc):
+        ctx = _Ctx()
+        _state(ctx).is_llm = True
+        result = svc.on_response_headers(_http_headers({"content-length": "1234"}), ctx)
+        assert "content-length" in result.response.header_mutation.remove_headers
+
+
+# ---------------------------------------------------------------------------
+# on_response_body  (dispatch)
+# ---------------------------------------------------------------------------
+
+class TestOnResponseBody:
+    def test_not_llm_returns_none(self, svc):
+        ctx = _Ctx()
+        assert svc.on_response_body(_body(b"whatever"), ctx) is None
+
+    def test_buffered_path_dispatched(self, svc):
+        ctx = _Ctx()
+        st = _state(ctx)
+        st.is_llm = True
+        st.is_streaming = False
+        st.model = "gemini-2.5-flash"
+        st.provider = "vertex_ai"
+        result = svc.on_response_body(_body(b"partial", end_of_stream=False), ctx)
+        # Intermediate chunk in buffered mode → body suppressed.
+        assert result.response.body_mutation.body == b""
+
+    def test_streaming_path_dispatched(self, svc):
+        ctx = _Ctx()
+        st = _state(ctx)
+        st.is_llm = True
+        st.is_streaming = True
+        st.provider = "openai"  # pass-through
+        result = svc.on_response_body(_body(b"data: x\n\n", end_of_stream=False), ctx)
+        assert isinstance(result, service_pb2.BodyResponse)
+
+
+# ---------------------------------------------------------------------------
+# _handle_buffered_chunk
+# ---------------------------------------------------------------------------
+
+class TestHandleBufferedChunk:
+    def test_intermediate_chunk_suppressed(self, svc):
+        state = _StreamState(model="m", provider="vertex_ai")
+        result = svc._handle_buffered_chunk(state, b"partial", end_of_stream=False)
+        assert result.response.body_mutation.body == b""
+
+    def test_accumulates_across_chunks(self, svc):
+        state = _StreamState(model="m", provider="vertex_ai")
+        svc._handle_buffered_chunk(state, b"abc", end_of_stream=False)
+        svc._handle_buffered_chunk(state, b"def", end_of_stream=False)
+        assert bytes(state.body_buffer) == b"abcdef"
+
+    def test_vertex_response_transformed_to_openai_on_eos(self, svc):
+        state = _StreamState(
+            model="gemini-2.5-flash", provider="vertex_ai",
+            request_body={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        vertex_resp = {
+            "candidates": [{
+                "content": {"role": "model", "parts": [{"text": "Hello!"}]},
+                "finishReason": "STOP",
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 5, "candidatesTokenCount": 3, "totalTokenCount": 8,
+            },
+            "modelVersion": "gemini-2.5-flash",
+        }
+        result = svc._handle_buffered_chunk(
+            state, json.dumps(vertex_resp).encode(), end_of_stream=True)
+        out = json.loads(result.response.body_mutation.body)
+        assert out["object"] == "chat.completion"
+        assert out["choices"][0]["message"]["content"] == "Hello!"
+        assert out["choices"][0]["message"]["role"] == "assistant"
+
+    def test_invalid_json_passes_raw_body_on_eos(self, svc):
+        state = _StreamState(model="m", provider="vertex_ai")
+        raw = b"not-valid-json"
+        result = svc._handle_buffered_chunk(state, raw, end_of_stream=True)
+        assert result.response.body_mutation.body == raw
+
+    def test_unknown_provider_passes_through_on_eos(self, svc):
+        state = _StreamState(model="m", provider="not-a-real-provider")
+        raw = json.dumps({"choices": [{"message": {"content": "x"}}]}).encode()
+        result = svc._handle_buffered_chunk(state, raw, end_of_stream=True)
+        # Falls back to returning the parsed JSON unchanged.
+        assert json.loads(result.response.body_mutation.body) == json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# _handle_streaming_chunk
+# ---------------------------------------------------------------------------
+
+class TestHandleStreamingChunk:
+    def test_openai_compat_provider_passes_through(self, svc):
+        state = _StreamState(model="m", provider="openai")
+        raw = b"data: {\"choices\":[]}\n\n"
+        result = svc._handle_streaming_chunk(state, raw, end_of_stream=False)
+        assert result.response.body_mutation.body == raw
+
+    def test_done_appended_on_eos_for_transforming_provider(self, svc):
+        state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
+        result = svc._handle_streaming_chunk(state, b"", end_of_stream=True)
+        assert b"data: [DONE]\n\n" in result.response.body_mutation.body
+
+    def test_partial_event_held_in_buffer(self, svc):
+        state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
+        result = svc._handle_streaming_chunk(state, b"data: {", end_of_stream=False)
+        assert result.response.body_mutation.body == b""
+        assert "data: {" in state.sse_buffer
+
+    def test_done_sentinel_in_stream_skipped(self, svc):
+        state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
+        result = svc._handle_streaming_chunk(state, b"data: [DONE]\n\n", end_of_stream=False)
+        assert result.response.body_mutation.body == b""
+
+    def test_non_json_sse_data_skipped(self, svc):
+        state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
+        result = svc._handle_streaming_chunk(state, b"data: not-json\n\n", end_of_stream=False)
+        assert result.response.body_mutation.body == b""
+
+    def test_crlf_normalized(self, svc):
+        # Vertex emits CRLF-delimited SSE; ensure we still split events.
+        state = _StreamState(model="gemini-2.5-flash", provider="vertex_ai")
+        # An empty/comment event with CRLF — should consume cleanly, no crash.
+        svc._handle_streaming_chunk(state, b": ping\r\n\r\n", end_of_stream=False)
+        assert state.sse_buffer == ""

--- a/callouts/python/requirements-test.txt
+++ b/callouts/python/requirements-test.txt
@@ -1,3 +1,6 @@
 pytest==9.0.3
 google-cloud-logging==3.9.0
 pyjwt[crypto]==2.12.0
+litellm==1.83.0
+httpx>=0.27,<1.0
+google-cloud-aiplatform>=1.50.0


### PR DESCRIPTION
Adds a litellm_gateway Python sample — a Service Extensions ext_proc callout that turns a Google Cloud external Application Load Balancer into an OpenAI-compatible multi-provider gateway. 

The LB routes each request to the right provider backend (Vertex AI, Anthropic, Groq, OpenRouter) via Internet NEGs; the callout runs LiteLLM in-process to translate OpenAI ↔ provider formats and inject the right auth (ADC for Vertex AI; Secret Manager–backed API keys for the others). 

The callout doesn't proxy traffic — it only mutates the body and headers, and the LB forwards straight to the provider. Routing is header-driven (x-v2-target-provider, derived from the model id) 