### PR TITLE
Add implementation of error that does not abort

### DIFF
--- a/plugins/test/framework.cc
+++ b/plugins/test/framework.cc
@@ -19,11 +19,10 @@
 #include <utility>
 #include <vector>
 
-#include <boost/dll/runtime_symbol_info.hpp>
-
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+#include "boost/dll/runtime_symbol_info.hpp"
 
 namespace service_extensions_samples {
 
@@ -86,6 +85,10 @@ proxy_wasm::WasmResult TestContext::log(uint32_t log_level,
 }
 ContextOptions& TestContext::options() const {
   return static_cast<TestWasm*>(wasm())->options();
+}
+
+void TestContext::error(std::string_view message) {
+  std::cerr << message << "\n";
 }
 
 proxy_wasm::BufferInterface* TestHttpContext::getBuffer(
@@ -221,7 +224,7 @@ TestHttpContext::Result TestHttpContext::SendRequestBody(std::string body,
   body_buffer_.setOwned(std::move(body));
   current_callback_ = TestHttpContext::CallbackType::RequestBody;
   result_.body_status = onRequestBody(body_buffer_.size(), end_of_stream);
-    result_.body = body_buffer_.release();
+  result_.body = body_buffer_.release();
   return std::move(result_);
 }
 
@@ -242,7 +245,7 @@ TestHttpContext::Result TestHttpContext::SendResponseHeaders(
 }
 
 TestHttpContext::Result TestHttpContext::SendResponseBody(std::string body,
-                                                         bool end_of_stream) {
+                                                          bool end_of_stream) {
   phase_logs_.clear();
   result_ = Result{};
   if (sent_local_response_) {

--- a/plugins/test/framework.h
+++ b/plugins/test/framework.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem/path.hpp>
 #include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "boost/algorithm/string.hpp"
+#include "boost/filesystem/path.hpp"
 #include "gtest/gtest.h"
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/wasm.h"
@@ -102,6 +102,7 @@ class TestContext : public proxy_wasm::TestContext {
   uint64_t getMonotonicTimeNanoseconds() override;
   proxy_wasm::WasmResult log(uint32_t log_level,
                              std::string_view message) override;
+  void error(std::string_view message) override;
   // --- END   Wasm facing API ---
 
   // --- BEGIN Testing facilities ---
@@ -178,7 +179,7 @@ class TestHttpContext : public TestContext {
       proxy_wasm::WasmHeaderMapType type,
       const proxy_wasm::Pairs& pairs) override;
   proxy_wasm::WasmResult getProperty(std::string_view path,
-                                    std::string* result) override;
+                                     std::string* result) override;
 
   // Ignore failStream, avoid calling unimplemented closeStream.
   void failStream(proxy_wasm::WasmStreamType) override {}


### PR DESCRIPTION
The default implementation of `proxy_wasm::ContextBase::error` calls `abort()`. This is not very helpful, since it crashes the test runner.