### PR TITLE
feat: Add a Python Callout implementation for Portkey sample

### DIFF
--- a/callouts/python/extproc/example/portkey_gateway/Dockerfile
+++ b/callouts/python/extproc/example/portkey_gateway/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the proto libraries from the envoy git repo using buf.
+FROM bufbuild/buf AS BUF
+RUN apk add --no-cache git
+COPY ./buf.gen.yaml ./buf.gen.yaml
+ARG proto_path="envoy/service/ext_proc/v3/external_processor.proto"
+RUN buf -v generate https://github.com/envoyproxy/envoy.git#subdir=api \
+      --path $proto_path --include-imports
+
+# Service image. We preserve the package layout (extproc/example/portkey_gateway/...)
+# rather than flattening, because our service module imports siblings via the full
+# package path and relies on running as `python -m extproc.example.portkey_gateway.*`.
+FROM launcher.gcr.io/google/debian12
+
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y \
+ && apt-get install -y python3-pip --no-install-recommends --no-install-suggests \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ./requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt --break-system-packages --root-user-action=ignore
+
+WORKDIR /home/callouts/python
+
+# Generated proto packages drop into WORKDIR root (envoy/, etc.).
+COPY --from=BUF ./protodef .
+
+# Framework + our example, preserving the package structure.
+COPY ./extproc/__init__.py ./extproc/__init__.py
+COPY ./extproc/service ./extproc/service
+COPY ./extproc/ssl_creds ./extproc/ssl_creds
+COPY ./extproc/example/__init__.py ./extproc/example/__init__.py
+COPY ./extproc/example/portkey_gateway ./extproc/example/portkey_gateway
+
+# Example-specific dependencies (httpx, aiohttp, google-auth).
+RUN pip install -r ./extproc/example/portkey_gateway/additional-requirements.txt \
+      --break-system-packages --root-user-action=ignore
+
+EXPOSE 80 443 8080
+
+ENTRYPOINT ["python3", "-um", "extproc.example.portkey_gateway.service_callout_example"]

--- a/callouts/python/extproc/example/portkey_gateway/README.md
+++ b/callouts/python/extproc/example/portkey_gateway/README.md
@@ -1,0 +1,382 @@
+# Portkey Gateway
+
+A Service Extensions `ext_proc` callout that fronts a self-hosted **Portkey AI
+gateway** to turn a Google Cloud external Application Load Balancer into an
+OpenAI-compatible multi-provider gateway. The callout itself does **not** proxy
+traffic; it only mutates request and response headers and bodies. Vanilla
+OpenAI clients send requests in, the callout rewrites them to provider-native
+bytes, and the LB forwards the result to the matching Internet NEG backend
+(api.anthropic.com, Vertex AI, Groq, OpenRouter, and so on). Portkey runs as a
+**sidecar container** in the same Cloud Run service, no separate deployment.
+The callout uses Portkey's `custom_host` feature to intercept the translated
+bytes on a loopback port rather than letting Portkey actually call the
+provider; the LB owns the outbound connection. Streaming (`stream: true`) is
+not supported in this sample and is rejected with HTTP 501.
+
+## Architecture
+
+```
+                       x-model-id: anthropic/claude-...
+  Client ───────────────────────────────────────────────────────────────┐
+   │  POST /v1/chat/completions (OpenAI body, model="provider/...")     │
+   ▼                                                                    │
+ ┌──────────────────────────────────────────────────────────────────────┴───┐
+ │ ┌────────────────────────────┐        ┌────────────────────────────────┐ │
+ │ │ URL Map                    │        │ Traffic Extension callout      │ │
+ │ │  /v1/* + x-model-id        │  body  │ PortkeyGatewayCallout/Cloud Run│ │
+ │ │   prefix match on:         ├───────►│  1. parse model/provider       │ │
+ │ │    anthropic/   → BE-A     │◄───────┤  2. mint auth (ADC or API key) │ │
+ │ │    groq/        → BE-G     │ headers│  3. call Portkey sidecar at    │ │
+ │ │    openrouter/  → BE-O     │ +body  │     localhost:8787 with        │ │
+ │ │   /v1/* default → BE-V     │        │     custom_host = :9999        │ │
+ │ └──────────┬─────────────────┘        │  4. capture translated bytes   │ │
+ │            │ LB forwards              │     POSTed back to :9999       │ │
+ │            ▼                          │  5. return as ext_proc body    │ │
+ │ ┌────┐ ┌────┐ ┌────┐ ┌────┐           │     and header mutations       │ │
+ │ │BE-V│ │BE-A│ │BE-G│ │BE-O│           └────────────────────────────────┘ │
+ │ │ NEG│ │ NEG│ │ NEG│ │ NEG│                                              │
+ │ └─┬──┘ └─┬──┘ └─┬──┘ └─┬──┘                                              │
+ └───┼──────┼──────┼──────┼─────────────────────────────────────────────────┘
+     ▼      ▼      ▼      ▼
+  BE-V: {region}-aiplatform.googleapis.com    BE-A: api.anthropic.com
+  BE-G: api.groq.com                          BE-O: openrouter.ai
+
+  ─── Portkey sidecar loopback (request phase) ───────────────────────────────
+  Callout ──OpenAI body──► Portkey :8787 (custom_host=http://127.0.0.1:9999)
+                                │  Portkey translates and POSTs provider bytes
+                                ▼
+                          Capture server :9999  ──► Callout reads captured bytes
+                                                     (returned to LB as mutations)
+
+  ─── Portkey sidecar loopback (response phase) ──────────────────────────────
+  LB delivers provider response ──► Callout arms :9998 with provider bytes
+  Callout ──original OpenAI body──► Portkey :8787 (custom_host=http://127.0.0.1:9998)
+                                          │  Portkey reads replayed provider bytes
+                                          ▼
+                                    Portkey returns OpenAI-shaped response
+                                    Callout returns that to the LB (body mutation)
+```
+
+## How It Works
+
+1. **Client** sends a standard OpenAI request (`POST /v1/chat/completions`,
+   body `{"model": "anthropic/claude-3-5-sonnet-...", "messages": [...]}`)
+   plus a routing header `x-model-id: anthropic/claude-3-5-sonnet-...` (the
+   same value as the body's `model` field).
+2. **URL Map** evaluates `prefix=/v1/` plus a `prefix_match` on the
+   `x-model-id` header (`anthropic/`, `groq/`, `openrouter/`) and selects the
+   matching backend service (e.g. the Anthropic Internet NEG). `/v1/*`
+   requests with no matching prefix fall through to the Vertex AI backend;
+   non-LLM paths go to the upstream app.
+3. **Traffic Extension** intercepts the request and streams the headers and body
+   to the callout over gRPC (`REQUEST_HEADERS`, then `REQUEST_BODY`).
+4. **Callout** (`service_callout_example.py`) parses the `model` field to detect
+   the provider (`anthropic/claude-…` → `anthropic`), then mints auth: a short-
+   lived ADC bearer token for Vertex AI, or reads the provider's `*_API_KEY` env
+   var (mounted from Secret Manager) for the others.
+5. **Callout** arms the capture server on `:9999`, then sends the OpenAI body to
+   the Portkey sidecar at `localhost:8787` with
+   `x-portkey-custom-host: http://127.0.0.1:9999` and the provider API key.
+6. **Portkey sidecar** translates the OpenAI request to the provider's native
+   format and POSTs the translated bytes to `:9999`, where the callout's capture
+   server records the path, headers, and body.
+7. **Callout** reads the captured bytes and returns them as ext_proc mutations
+   (body + header rewrites for `:path`, `:authority`, `content-length`, auth,
+   etc.). The LB forwards the provider-native request to the provider Internet
+   NEG already selected by the URL map.
+8. **Response phase**: the LB delivers the provider's native response to the
+   callout. The callout arms `:9998` with those bytes, then calls the Portkey
+   sidecar again with `x-portkey-custom-host: http://127.0.0.1:9998`. Portkey
+   GETs the replayed bytes from `:9998` and translates them back to the OpenAI
+   response shape.
+9. **Client** receives a standard OpenAI-format response, same shape regardless
+   of which provider served it.
+
+### The `x-model-id` header
+
+The client sends `x-model-id: <provider>/<model_id>` alongside the request, with the same
+value as the body's `model` field. This is required because a GCLB URL map
+evaluates backend routing rules **before** any ext_proc callout runs, so the
+callout cannot influence which backend the LB has already selected. Routing
+must therefore be header-driven.
+
+The URL map uses a `prefix_match` on the provider segment of the model id
+(for example, `anthropic/` matches `anthropic/claude-3-5-sonnet-...`). Because
+the header value is just the body's `model` field, the client does not need
+any extra mapping logic. The sample UI sets it automatically from the
+selected model; OpenAI-style SDK clients can set it via `default_headers`.
+A `/v1/*` request with no matching prefix falls through to the Vertex AI
+backend.
+
+### Supported endpoints
+
+| Path | Type |
+|------|------|
+| `/v1/chat/completions` | Chat |
+| `/v1/completions` | Text completion |
+| `/v1/embeddings` | Embeddings |
+
+Only `/v1/`-prefixed paths are supported: the URL map's provider route rules
+match on the `/v1/` prefix, so a request on an unprefixed path can never
+reach a provider backend.
+
+## Providers
+
+The sample ships with four provider backends. The model id
+(`provider/model` convention) is what gets sent in both the request body's
+`model` field and the routing `x-model-id` header; the URL map's
+`prefix_match` picks the backend from the provider segment:
+
+| Provider | Example model id | Upstream | Auth |
+|----------|-----------------|----------|------|
+| Vertex AI | `vertex_ai/gemini-2.5-flash` | `{region}-aiplatform.googleapis.com` | ADC (Cloud Run service identity, `roles/aiplatform.user`) |
+| Anthropic | `anthropic/claude-3-5-sonnet-20241022` | `api.anthropic.com` | `ANTHROPIC_API_KEY` env var (Secret Manager) |
+| Groq | `groq/compound-beta` | `api.groq.com` | `GROQ_API_KEY` env var (Secret Manager) |
+| OpenRouter | `openrouter/openai/gpt-oss-20b:free` | `openrouter.ai` | `OPENROUTER_API_KEY` env var (Secret Manager) |
+
+The `vertex_ai` prefix selects Google's published models served by the
+Vertex AI API (now delivered as part of the Gemini Enterprise agent
+platform). The endpoint, IAM role, and Portkey provider id (`vertex-ai`)
+keep their existing names.
+
+Anthropic's Messages API requires `max_tokens`, which OpenAI clients usually
+omit. The callout fills in a default of 4096 when the field is absent.
+
+### Adding a provider
+
+1. Add a `ProviderSpec` entry to `PROVIDERS` in
+   `extproc/example/portkey_gateway/service_callout_example.py`: supply the
+   Portkey provider id, the Internet NEG FQDN, and the API-key env var name (or
+   `None` for ADC).
+2. Add a matching entry to `_STUBS` in `capture_server.py` that reflects the
+   provider's response shape (used by the unit test suite).
+3. If the provider needs an API key, add a `*_api_key` variable in
+   `deploy/terraform/variables.tf` and wire it into the `env` block of the
+   callout Cloud Run service in `deploy/terraform/main.tf`.
+4. Add the provider FQDN to the Internet NEG and URL-map `header_matches` list
+   in `deploy/terraform/main.tf`.
+
+## Deploy to Google Cloud
+
+> [!IMPORTANT]
+> There is intentionally **no local-dev path** for this sample. The ext_proc
+> chain depends on a real GCLB URL map with `header_matches` routing, which an
+> Envoy stand-in does not replicate faithfully. Deploy to GCP to exercise it.
+
+### Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) authenticated with ADC
+- A GCP project with Vertex AI enabled and Gemini accessible in your region
+- API keys for any non-Vertex providers you want to use
+
+#### IAM roles
+
+Scoped for sample/testing deployments. Use least-privilege equivalents in
+production.
+
+| Role | Purpose |
+|------|---------|
+| `roles/compute.admin` | Load balancer, backend services, NEGs |
+| `roles/run.admin` | Cloud Run services, revisions, IAM bindings |
+| `roles/networkservices.admin` | Service Extensions traffic extension |
+| `roles/iam.serviceAccountUser` | Bind the Cloud Run service account |
+| `roles/artifactregistry.admin` | Create repos, push/pull images |
+| `roles/secretmanager.admin` | Create secrets for provider API keys |
+| `roles/serviceusage.serviceUsageAdmin` | Enable required GCP APIs |
+| `roles/cloudbuild.builds.editor` | Submit Cloud Build jobs |
+| `roles/storage.admin` | Cloud Build source staging bucket |
+
+The callout runs under the project's default compute service account by default
+(it carries `roles/editor`, enough for Vertex AI ADC). For tighter scoping,
+create an SA with only `roles/aiplatform.user` and set
+`var.callout_service_account` to its email.
+
+### 1. Authenticate
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### 2. Enable required APIs
+
+```bash
+gcloud services enable \
+  aiplatform.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com \
+  compute.googleapis.com \
+  iam.googleapis.com \
+  networkservices.googleapis.com \
+  run.googleapis.com \
+  secretmanager.googleapis.com
+```
+
+### 3. Create the Artifact Registry repository
+
+```bash
+gcloud artifacts repositories create portkey-gateway \
+  --repository-format=docker --location=us-central1
+```
+
+### 4. Build and push the callout image
+
+The Portkey sidecar uses the upstream `portkeyai/gateway` image pulled from
+Docker Hub, so no separate build is needed for it. Only the callout image
+needs to be built (run from `callouts/python/`, the build context is the
+package root):
+
+```bash
+cd callouts/python
+gcloud builds submit \
+  --config=extproc/example/portkey_gateway/cloudbuild.yaml \
+  --project=YOUR_PROJECT_ID
+```
+
+(Optional) Sample chat UI image: serves as the upstream app for non-LLM paths
+and lets you exercise the gateway from a browser. It sets the `x-model-id`
+header automatically based on the selected model:
+
+```bash
+cd extproc/example/portkey_gateway/sample-ui
+gcloud builds submit --config=cloudbuild.yaml --project=YOUR_PROJECT_ID
+```
+
+If you build the sample UI, set `upstream_app_image` in `terraform.tfvars` to
+the resulting image path
+(`us-central1-docker.pkg.dev/YOUR_PROJECT_ID/portkey-gateway/sample-ui:latest`)
+before running `terraform apply`.
+
+### 5. Configure and apply Terraform
+
+```bash
+cd extproc/example/portkey_gateway/deploy/terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: project_id, region, callout_image, and the
+# *_api_key values for the providers you want to use.
+terraform init
+terraform plan
+terraform apply
+```
+
+Terraform creates a **multi-container Cloud Run service**: the callout container
+plus a `portkeyai/gateway` sidecar. API keys you put in `terraform.tfvars` are
+uploaded to Secret Manager and mounted as env vars (`secret_key_ref`). They
+never appear as plain values in the console.
+
+### 6. Test the deployment
+
+```bash
+LB_IP=$(terraform output -raw load_balancer_ip)
+
+# Vertex AI (no header needed, it's the default backend)
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"vertex_ai/gemini-2.5-flash","messages":[{"role":"user","content":"Say hi"}]}'
+
+# Anthropic
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: anthropic/claude-3-5-sonnet-20241022" \
+  -d '{"model":"anthropic/claude-3-5-sonnet-20241022","max_tokens":64,"messages":[{"role":"user","content":"Say hi"}]}'
+
+# Groq
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: groq/compound-beta" \
+  -d '{"model":"groq/compound-beta","messages":[{"role":"user","content":"Say hi"}]}'
+
+# OpenRouter
+curl -sk -X POST https://$LB_IP/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-model-id: openrouter/openai/gpt-oss-20b:free" \
+  -d '{"model":"openrouter/openai/gpt-oss-20b:free","messages":[{"role":"user","content":"Say hi"}]}'
+```
+
+If you deployed the sample UI as upstream, open `https://$LB_IP/` in a browser
+(accept the self-signed cert). It sets the `x-model-id` header for you based
+on the model you pick.
+
+To see the LB pick a different backend per request, enable logging on the
+backend services (Terraform sets `log_config { enable = true }`) and query:
+
+```bash
+gcloud logging read 'resource.type="http_load_balancer"' \
+  --project=YOUR_PROJECT_ID --limit=10 --freshness=5m \
+  --format="value(timestamp,httpRequest.requestUrl,httpRequest.status,resource.labels.backend_service_name)"
+```
+
+### 7. Tear down
+
+```bash
+terraform destroy
+gcloud artifacts repositories delete portkey-gateway --location=us-central1 --quiet
+gcloud storage rm -r gs://YOUR_PROJECT_ID_cloudbuild/
+```
+
+### What gets deployed
+
+| Resource | Purpose |
+|----------|---------|
+| Cloud Run (callout + sidecar) | Multi-container service: the ext_proc callout and the `portkeyai/gateway` sidecar |
+| Global external Application LB | Entry point with a self-signed cert |
+| Internet NEGs (×4) + backend services | Vertex AI, Anthropic, Groq, OpenRouter |
+| Serverless NEG | Cloud Run callout |
+| URL map | `header_matches` routing to provider backends; default → Vertex AI |
+| Traffic Extension | Invokes the callout for LLM paths |
+| Secret Manager secrets | Provider API keys (only the non-empty ones) |
+
+## Testing
+
+```bash
+cd callouts/python
+pip install -r requirements.txt -r requirements-test.txt \
+  -r extproc/example/portkey_gateway/additional-requirements.txt
+python -m pytest extproc/tests/portkey_gateway_test.py -v
+```
+
+The suite is pure unit tests: no gRPC server, no live Portkey sidecar, no
+GCP credentials required. It covers provider detection, Vertex ADC token
+minting (patched), capture-server arm/take/disarm mechanics, the request-side
+and response-side loopback paths, streaming rejection (HTTP 501), and full
+end-to-end ext_proc phase sequences for all four providers.
+
+## File structure
+
+```
+portkey_gateway/
+├── service_callout_example.py      # ext_proc callout + provider registry + Vertex ADC auth
+├── capture_server.py               # Loopback capture servers (:9999 and :9998) + stub responses
+├── portkey_client.py               # Async HTTP client wrapping the Portkey sidecar
+├── additional-requirements.txt     # httpx, aiohttp, google-auth, requests
+├── cloudbuild.yaml                 # Cloud Build config for the callout image
+├── Dockerfile                      # Callout container image
+├── README.md
+├── deploy/
+│   └── terraform/
+│       ├── main.tf                 # LB, NEGs, backends, URL map, Traffic Ext,
+│       │                           # multi-container Cloud Run, secrets
+│       ├── variables.tf
+│       └── terraform.tfvars.example
+└── sample-ui/                      # Optional chat UI; sets x-model-id per model
+    ├── index.html
+    ├── Dockerfile
+    └── cloudbuild.yaml
+```
+
+(Unit tests live at `extproc/tests/portkey_gateway_test.py`.)
+
+## Environment variables (callout)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GCP_PROJECT_ID` | (none) | Required for Vertex AI; used to build the Vertex URL and passed to the Portkey sidecar as `x-portkey-vertex-project-id`. |
+| `GCP_REGION` | `us-central1` | Vertex AI region; also determines the Internet NEG FQDN (`{region}-aiplatform.googleapis.com`). |
+| `PORTKEY_BASE_URL` | `http://127.0.0.1:8787` | URL of the Portkey sidecar. Change only if you run Portkey on a different port or host. |
+| `CAPTURE_REQUEST_PORT` | `9999` | Port the callout's request capture server listens on. |
+| `CAPTURE_RESPONSE_PORT` | `9998` | Port the callout's response capture server listens on. |
+| `ANTHROPIC_API_KEY` | (none) | API key for Anthropic requests. Mounted from Secret Manager. |
+| `GROQ_API_KEY` | (none) | API key for Groq requests. Mounted from Secret Manager. |
+| `OPENROUTER_API_KEY` | (none) | API key for OpenRouter requests. Mounted from Secret Manager. |

--- a/callouts/python/extproc/example/portkey_gateway/README.md
+++ b/callouts/python/extproc/example/portkey_gateway/README.md
@@ -41,20 +41,23 @@ not supported in this sample and is rejected with HTTP 501.
   BE-V: {region}-aiplatform.googleapis.com    BE-A: api.anthropic.com
   BE-G: api.groq.com                          BE-O: openrouter.ai
 
-  ─── Portkey sidecar loopback (request phase) ───────────────────────────────
+  ─── Portkey sidecar loopback (one call, parked across both phases) ─────────
   Callout ──OpenAI body──► Portkey :8787 (custom_host=http://127.0.0.1:9999)
                                 │  Portkey translates and POSTs provider bytes
                                 ▼
-                          Capture server :9999  ──► Callout reads captured bytes
-                                                     (returned to LB as mutations)
-
-  ─── Portkey sidecar loopback (response phase) ──────────────────────────────
-  LB delivers provider response ──► Callout arms :9998 with provider bytes
-  Callout ──original OpenAI body──► Portkey :8787 (custom_host=http://127.0.0.1:9998)
-                                          │  Portkey reads replayed provider bytes
-                                          ▼
-                                    Portkey returns OpenAI-shaped response
-                                    Callout returns that to the LB (body mutation)
+                          Capture server :9999
+                                │  records the request, then PARKS the
+                                │  connection without answering
+                                ├──► Callout reads captured bytes
+                                │    (returned to LB as mutations)
+                                │
+                                │  ... LB calls the provider ...
+                                │
+                                ◄──  Callout hands the provider response to
+                                │    the capture server, which writes it on
+                                ▼    the parked connection
+                          Portkey translates it and the original call returns
+                          the OpenAI-shaped response to the callout
 ```
 
 ## How It Works
@@ -76,19 +79,21 @@ not supported in this sample and is rejected with HTTP 501.
    var (mounted from Secret Manager) for the others.
 5. **Callout** arms the capture server on `:9999`, then sends the OpenAI body to
    the Portkey sidecar at `localhost:8787` with
-   `x-portkey-custom-host: http://127.0.0.1:9999` and the provider API key.
+   `x-portkey-custom-host: http://127.0.0.1:9999` and the provider API key. It
+   does not wait for that call to finish.
 6. **Portkey sidecar** translates the OpenAI request to the provider's native
    format and POSTs the translated bytes to `:9999`, where the callout's capture
-   server records the path, headers, and body.
+   server records the path, headers, and body and then holds the connection
+   open without answering.
 7. **Callout** reads the captured bytes and returns them as ext_proc mutations
    (body + header rewrites for `:path`, `:authority`, `content-length`, auth,
    etc.). The LB forwards the provider-native request to the provider Internet
    NEG already selected by the URL map.
 8. **Response phase**: the LB delivers the provider's native response to the
-   callout. The callout arms `:9998` with those bytes, then calls the Portkey
-   sidecar again with `x-portkey-custom-host: http://127.0.0.1:9998`. Portkey
-   GETs the replayed bytes from `:9998` and translates them back to the OpenAI
-   response shape.
+   callout, which hands it to the capture server. The capture server writes it
+   as the response on the parked connection, so Portkey sees one ordinary
+   request/response exchange and translates it back to the OpenAI shape. The
+   call started in step 5 resolves with that translation.
 9. **Client** receives a standard OpenAI-format response, same shape regardless
    of which provider served it.
 
@@ -148,12 +153,10 @@ omit. The callout fills in a default of 4096 when the field is absent.
    `extproc/example/portkey_gateway/service_callout_example.py`: supply the
    Portkey provider id, the Internet NEG FQDN, and the API-key env var name (or
    `None` for ADC).
-2. Add a matching entry to `_STUBS` in `capture_server.py` that reflects the
-   provider's response shape (used by the unit test suite).
-3. If the provider needs an API key, add a `*_api_key` variable in
+2. If the provider needs an API key, add a `*_api_key` variable in
    `deploy/terraform/variables.tf` and wire it into the `env` block of the
    callout Cloud Run service in `deploy/terraform/main.tf`.
-4. Add the provider FQDN to the Internet NEG and URL-map `header_matches` list
+3. Add the provider FQDN to the Internet NEG and URL-map `header_matches` list
    in `deploy/terraform/main.tf`.
 
 ## Deploy to Google Cloud
@@ -339,8 +342,8 @@ python -m pytest extproc/tests/portkey_gateway_test.py -v
 
 The suite is pure unit tests: no gRPC server, no live Portkey sidecar, no
 GCP credentials required. It covers provider detection, Vertex ADC token
-minting (patched), capture-server arm/take/disarm mechanics, the request-side
-and response-side loopback paths, streaming rejection (HTTP 501), and full
+minting (patched), capture-server parking and release, the full loopback
+cycle across both ext_proc phases, streaming rejection (HTTP 501), and
 end-to-end ext_proc phase sequences for all four providers.
 
 ## File structure
@@ -348,7 +351,7 @@ end-to-end ext_proc phase sequences for all four providers.
 ```
 portkey_gateway/
 ├── service_callout_example.py      # ext_proc callout + provider registry + Vertex ADC auth
-├── capture_server.py               # Loopback capture servers (:9999 and :9998) + stub responses
+├── capture_server.py               # Loopback capture server (:9999) with connection parking
 ├── portkey_client.py               # Async HTTP client wrapping the Portkey sidecar
 ├── additional-requirements.txt     # httpx, aiohttp, google-auth, requests
 ├── cloudbuild.yaml                 # Cloud Build config for the callout image
@@ -375,8 +378,7 @@ portkey_gateway/
 | `GCP_PROJECT_ID` | (none) | Required for Vertex AI; used to build the Vertex URL and passed to the Portkey sidecar as `x-portkey-vertex-project-id`. |
 | `GCP_REGION` | `us-central1` | Vertex AI region; also determines the Internet NEG FQDN (`{region}-aiplatform.googleapis.com`). |
 | `PORTKEY_BASE_URL` | `http://127.0.0.1:8787` | URL of the Portkey sidecar. Change only if you run Portkey on a different port or host. |
-| `CAPTURE_REQUEST_PORT` | `9999` | Port the callout's request capture server listens on. |
-| `CAPTURE_RESPONSE_PORT` | `9998` | Port the callout's response capture server listens on. |
+| `CAPTURE_PORT` | `9999` | Port the callout's capture server listens on. Portkey is pointed at it via `x-portkey-custom-host`. |
 | `ANTHROPIC_API_KEY` | (none) | API key for Anthropic requests. Mounted from Secret Manager. |
 | `GROQ_API_KEY` | (none) | API key for Groq requests. Mounted from Secret Manager. |
 | `OPENROUTER_API_KEY` | (none) | API key for OpenRouter requests. Mounted from Secret Manager. |

--- a/callouts/python/extproc/example/portkey_gateway/additional-requirements.txt
+++ b/callouts/python/extproc/example/portkey_gateway/additional-requirements.txt
@@ -1,0 +1,4 @@
+httpx>=0.27,<1.0
+aiohttp>=3.9,<4.0
+google-auth>=2.28,<3.0
+requests>=2.31,<3.0

--- a/callouts/python/extproc/example/portkey_gateway/capture_server.py
+++ b/callouts/python/extproc/example/portkey_gateway/capture_server.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Localhost HTTP server for the Portkey ``custom_host`` loopback.
+
+Two endpoints, both running in-process on the callout container:
+
+* **request port (``:9999``)**: Portkey POSTs the translated provider-native
+  request here. We record body + headers + path against a correlation id, then
+  return a stub response (so Portkey does not error parsing it).
+
+* **response port (``:9998``)**: when the LB sends the provider's response back
+  through the callout's response phase, we arm this endpoint with the captured
+  bytes; the callout then makes a second Portkey call with
+  ``x-portkey-custom-host`` pointing here, and Portkey reads our armed bytes as
+  if they were a real upstream response, runs its translator, and returns OpenAI
+  format.
+
+Correlation id (``X-Portkey-Callout-Correlation``) ties the two phases together
+so concurrent requests do not cross-contaminate. The callout generates the id
+(uuid4) and forwards it through Portkey via ``x-portkey-forward-headers``.
+
+The endpoints bind to 127.0.0.1 only. They are reachable only from inside the
+same Cloud Run pod (the Portkey sidecar shares the network namespace) and never
+from external traffic.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import NamedTuple
+
+from aiohttp import web
+
+# ---------------------------------------------------------------------------
+# Provider response stubs for the request-capture loopback
+#
+# When the callout uses the ``x-portkey-custom-host`` loopback to extract
+# provider-native request bytes from Portkey, the local capture endpoint
+# (``:9999``) has to return *something*: Portkey will try to parse it as the
+# provider's native response and translate it to OpenAI format. We discard that
+# translated reply (we only wanted the captured request); but Portkey must not
+# error parsing the stub, or it will fail the whole call.
+#
+# Each stub here is the minimum response shape that satisfies the corresponding
+# Portkey response transformer.
+# ---------------------------------------------------------------------------
+
+_STUBS: dict[str, dict] = {
+    "anthropic": {
+        "id": "msg_stub",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-stub",
+        "content": [{"type": "text", "text": ""}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    },
+    "vertex_ai": {
+        "candidates": [{
+            "content": {"role": "model", "parts": [{"text": ""}]},
+            "finishReason": "STOP",
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 0,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 0,
+        },
+    },
+    "groq": {
+        "id": "chatcmpl-stub",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "groq-stub",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": ""},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    },
+    "openrouter": {
+        "id": "chatcmpl-stub",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "openrouter-stub",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": ""},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    },
+}
+
+
+# Providers the stub generator knows about; derived from _STUBS so the two
+# can never drift apart.
+REQUEST_CAPTURE_PROVIDERS = tuple(_STUBS)
+
+
+def build_stub_response(provider: str) -> bytes:
+    """Return the JSON-encoded stub body for ``provider``.
+
+    Raises ``KeyError`` for unknown providers. Callers should validate against
+    ``REQUEST_CAPTURE_PROVIDERS`` first.
+    """
+    return json.dumps(_STUBS[provider]).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Capture server
+# ---------------------------------------------------------------------------
+
+# Correlation header contract shared with portkey_client (which forwards it
+# through Portkey via x-portkey-forward-headers).
+CORRELATION_HEADER = "x-portkey-callout-correlation"
+
+
+class CapturedRequest(NamedTuple):
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+
+class CaptureServer:
+    """Runs the :9999 and :9998 HTTP listeners with per-correlation state.
+
+    Pass ``request_port=0`` / ``response_port=0`` to let the OS pick an
+    ephemeral port (useful in tests). After ``start()`` the actual bound ports
+    are available as ``request_port`` / ``response_port`` attributes.
+    """
+
+    def __init__(self, request_port: int = 9999,
+                 response_port: int = 9998) -> None:
+        self._req_configured = request_port
+        self._rsp_configured = response_port
+        self._req_runner: web.AppRunner | None = None
+        self._rsp_runner: web.AppRunner | None = None
+        self._armed_request: dict[str, str] = {}      # corr -> provider
+        self._captured: dict[str, CapturedRequest] = {}
+        self._armed_response: dict[str, bytes] = {}   # corr -> response bytes
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        req_app = web.Application()
+        req_app.router.add_route("*", "/{tail:.*}", self._on_request_capture)
+        self._req_runner = web.AppRunner(req_app)
+        await self._req_runner.setup()
+        req_site = web.TCPSite(
+            self._req_runner, "127.0.0.1", self._req_configured)
+        await req_site.start()
+        # _server may be None on some aiohttp versions until the site is
+        # started; by this point start() has completed, so sockets are bound.
+        self.request_port = (
+            req_site._server.sockets[0]  # type: ignore[union-attr]
+            .getsockname()[1])
+
+        rsp_app = web.Application()
+        rsp_app.router.add_route("*", "/{tail:.*}", self._on_response_replay)
+        self._rsp_runner = web.AppRunner(rsp_app)
+        await self._rsp_runner.setup()
+        rsp_site = web.TCPSite(
+            self._rsp_runner, "127.0.0.1", self._rsp_configured)
+        await rsp_site.start()
+        self.response_port = (
+            rsp_site._server.sockets[0]  # type: ignore[union-attr]
+            .getsockname()[1])
+
+    async def stop(self) -> None:
+        if self._req_runner is not None:
+            await self._req_runner.cleanup()
+        if self._rsp_runner is not None:
+            await self._rsp_runner.cleanup()
+
+    # -- public arming / extraction API ------------------------------------
+
+    def arm_request(self, correlation: str, provider: str) -> None:
+        self._armed_request[correlation] = provider
+
+    def take_captured_request(self, correlation: str) -> CapturedRequest:
+        return self._captured.pop(correlation)
+
+    def arm_response(self, correlation: str, body: bytes) -> None:
+        self._armed_response[correlation] = body
+
+    def disarm(self, correlation: str) -> None:
+        """Drop any pending state for ``correlation``.
+
+        Called by the callout on error paths (Portkey call failed, capture
+        never happened) so abandoned correlations do not accumulate in a
+        long-running server.
+        """
+        self._armed_request.pop(correlation, None)
+        self._captured.pop(correlation, None)
+        self._armed_response.pop(correlation, None)
+
+    # -- handlers ----------------------------------------------------------
+
+    async def _on_request_capture(self, request: web.Request) -> web.Response:
+        corr = request.headers.get(CORRELATION_HEADER)
+        if corr is None or corr not in self._armed_request:
+            return web.Response(status=400, text="missing/unknown correlation")
+        provider = self._armed_request.pop(corr)
+        body = await request.read()
+        self._captured[corr] = CapturedRequest(
+            path=request.path_qs,
+            headers={k.lower(): v for k, v in request.headers.items()},
+            body=body,
+        )
+        return web.Response(
+            status=200,
+            body=build_stub_response(provider),
+            content_type="application/json",
+        )
+
+    async def _on_response_replay(self, request: web.Request) -> web.Response:
+        corr = request.headers.get(CORRELATION_HEADER)
+        if corr is None or corr not in self._armed_response:
+            return web.Response(status=400, text="missing/unknown correlation")
+        body = self._armed_response.pop(corr)
+        return web.Response(
+            status=200, body=body, content_type="application/json")

--- a/callouts/python/extproc/example/portkey_gateway/capture_server.py
+++ b/callouts/python/extproc/example/portkey_gateway/capture_server.py
@@ -14,120 +14,50 @@
 
 """Localhost HTTP server for the Portkey ``custom_host`` loopback.
 
-Two endpoints, both running in-process on the callout container:
+Portkey is configured to treat this server as the provider endpoint. A single
+port serves both ext_proc phases by *parking* the connection:
 
-* **request port (``:9999``)**: Portkey POSTs the translated provider-native
-  request here. We record body + headers + path against a correlation id, then
-  return a stub response (so Portkey does not error parsing it).
+1. Portkey POSTs the translated provider-native request here. The server
+   records the path, headers, and body, then holds the connection open
+   without writing a response.
+2. The callout takes the recorded bytes and returns them to the LB, which
+   forwards them to the real provider.
+3. When the provider's response reaches the callout's response phase, the
+   callout hands those bytes to this server, which finally writes them as the
+   response on the parked connection.
+4. Portkey reads that response and translates it back to OpenAI format.
 
-* **response port (``:9998``)**: when the LB sends the provider's response back
-  through the callout's response phase, we arm this endpoint with the captured
-  bytes; the callout then makes a second Portkey call with
-  ``x-portkey-custom-host`` pointing here, and Portkey reads our armed bytes as
-  if they were a real upstream response, runs its translator, and returns OpenAI
-  format.
+Parking matters because Portkey sees one ordinary request/response exchange
+on one connection, exactly as it would when calling a real provider. The
+callout therefore makes no assumptions about whether Portkey keeps state
+between a request and its response.
 
-Correlation id (``X-Portkey-Callout-Correlation``) ties the two phases together
-so concurrent requests do not cross-contaminate. The callout generates the id
-(uuid4) and forwards it through Portkey via ``x-portkey-forward-headers``.
+Correlation id (``X-Portkey-Callout-Correlation``) ties a parked connection to
+its ext_proc stream so concurrent requests do not cross-contaminate. The
+callout generates the id (uuid4) and forwards it through Portkey via
+``x-portkey-forward-headers``.
 
-The endpoints bind to 127.0.0.1 only. They are reachable only from inside the
-same Cloud Run pod (the Portkey sidecar shares the network namespace) and never
-from external traffic.
+The endpoint binds to 127.0.0.1 only. It is reachable only from inside the
+same Cloud Run pod (the Portkey sidecar shares the network namespace) and
+never from external traffic.
 """
 
 from __future__ import annotations
 
-import json
+import asyncio
+from dataclasses import dataclass, field
 from typing import NamedTuple
 
 from aiohttp import web
 
-# ---------------------------------------------------------------------------
-# Provider response stubs for the request-capture loopback
-#
-# When the callout uses the ``x-portkey-custom-host`` loopback to extract
-# provider-native request bytes from Portkey, the local capture endpoint
-# (``:9999``) has to return *something*: Portkey will try to parse it as the
-# provider's native response and translate it to OpenAI format. We discard that
-# translated reply (we only wanted the captured request); but Portkey must not
-# error parsing the stub, or it will fail the whole call.
-#
-# Each stub here is the minimum response shape that satisfies the corresponding
-# Portkey response transformer.
-# ---------------------------------------------------------------------------
-
-_STUBS: dict[str, dict] = {
-    "anthropic": {
-        "id": "msg_stub",
-        "type": "message",
-        "role": "assistant",
-        "model": "claude-stub",
-        "content": [{"type": "text", "text": ""}],
-        "stop_reason": "end_turn",
-        "usage": {"input_tokens": 0, "output_tokens": 0},
-    },
-    "vertex_ai": {
-        "candidates": [{
-            "content": {"role": "model", "parts": [{"text": ""}]},
-            "finishReason": "STOP",
-        }],
-        "usageMetadata": {
-            "promptTokenCount": 0,
-            "candidatesTokenCount": 0,
-            "totalTokenCount": 0,
-        },
-    },
-    "groq": {
-        "id": "chatcmpl-stub",
-        "object": "chat.completion",
-        "created": 0,
-        "model": "groq-stub",
-        "choices": [{
-            "index": 0,
-            "message": {"role": "assistant", "content": ""},
-            "finish_reason": "stop",
-        }],
-        "usage": {
-            "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-    },
-    "openrouter": {
-        "id": "chatcmpl-stub",
-        "object": "chat.completion",
-        "created": 0,
-        "model": "openrouter-stub",
-        "choices": [{
-            "index": 0,
-            "message": {"role": "assistant", "content": ""},
-            "finish_reason": "stop",
-        }],
-        "usage": {
-            "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-    },
-}
-
-
-# Providers the stub generator knows about; derived from _STUBS so the two
-# can never drift apart.
-REQUEST_CAPTURE_PROVIDERS = tuple(_STUBS)
-
-
-def build_stub_response(provider: str) -> bytes:
-    """Return the JSON-encoded stub body for ``provider``.
-
-    Raises ``KeyError`` for unknown providers. Callers should validate against
-    ``REQUEST_CAPTURE_PROVIDERS`` first.
-    """
-    return json.dumps(_STUBS[provider]).encode("utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Capture server
-# ---------------------------------------------------------------------------
-
 # Correlation header contract shared with portkey_client (which forwards it
 # through Portkey via x-portkey-forward-headers).
 CORRELATION_HEADER = "x-portkey-callout-correlation"
+
+# Upper bound on how long a connection stays parked. It must exceed the LB
+# backend timeout (see timeout_sec in deploy/terraform/main.tf) so that a slow
+# provider does not trip this first.
+DEFAULT_PARK_TIMEOUT = 300.0
 
 
 class CapturedRequest(NamedTuple):
@@ -136,102 +66,146 @@ class CapturedRequest(NamedTuple):
     body: bytes
 
 
-class CaptureServer:
-    """Runs the :9999 and :9998 HTTP listeners with per-correlation state.
+@dataclass
+class _Pending:
+    """State for one in-flight correlation."""
+    captured: CapturedRequest | None = None
+    captured_event: asyncio.Event = field(default_factory=asyncio.Event)
+    response: bytes | None = None
+    response_event: asyncio.Event = field(default_factory=asyncio.Event)
 
-    Pass ``request_port=0`` / ``response_port=0`` to let the OS pick an
-    ephemeral port (useful in tests). After ``start()`` the actual bound ports
-    are available as ``request_port`` / ``response_port`` attributes.
+
+class CaptureServer:
+    """Serves the Portkey ``custom_host`` loopback on a single port.
+
+    Pass ``port=0`` to let the OS pick an ephemeral port (useful in tests).
+    After ``start()`` the actual bound port is available as ``port``.
+
+    Every public coroutine is intended to be scheduled onto the server's own
+    event loop (the callout does this through ``_run_async``), so the
+    ``asyncio.Event`` objects are only ever touched from that loop.
     """
 
-    def __init__(self, request_port: int = 9999,
-                 response_port: int = 9998) -> None:
-        self._req_configured = request_port
-        self._rsp_configured = response_port
-        self._req_runner: web.AppRunner | None = None
-        self._rsp_runner: web.AppRunner | None = None
-        self._armed_request: dict[str, str] = {}      # corr -> provider
-        self._captured: dict[str, CapturedRequest] = {}
-        self._armed_response: dict[str, bytes] = {}   # corr -> response bytes
+    def __init__(self, port: int = 9999,
+                 park_timeout: float = DEFAULT_PARK_TIMEOUT) -> None:
+        self._configured_port = port
+        self._park_timeout = park_timeout
+        self._runner: web.AppRunner | None = None
+        self._pending: dict[str, _Pending] = {}
+        self.port = port
 
     # -- lifecycle ---------------------------------------------------------
 
     async def start(self) -> None:
-        req_app = web.Application()
-        req_app.router.add_route("*", "/{tail:.*}", self._on_request_capture)
-        self._req_runner = web.AppRunner(req_app)
-        await self._req_runner.setup()
-        req_site = web.TCPSite(
-            self._req_runner, "127.0.0.1", self._req_configured)
-        await req_site.start()
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._on_capture)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", self._configured_port)
+        await site.start()
         # _server may be None on some aiohttp versions until the site is
         # started; by this point start() has completed, so sockets are bound.
-        self.request_port = (
-            req_site._server.sockets[0]  # type: ignore[union-attr]
-            .getsockname()[1])
-
-        rsp_app = web.Application()
-        rsp_app.router.add_route("*", "/{tail:.*}", self._on_response_replay)
-        self._rsp_runner = web.AppRunner(rsp_app)
-        await self._rsp_runner.setup()
-        rsp_site = web.TCPSite(
-            self._rsp_runner, "127.0.0.1", self._rsp_configured)
-        await rsp_site.start()
-        self.response_port = (
-            rsp_site._server.sockets[0]  # type: ignore[union-attr]
+        self.port = (
+            site._server.sockets[0]  # type: ignore[union-attr]
             .getsockname()[1])
 
     async def stop(self) -> None:
-        if self._req_runner is not None:
-            await self._req_runner.cleanup()
-        if self._rsp_runner is not None:
-            await self._rsp_runner.cleanup()
+        if self._runner is not None:
+            await self._runner.cleanup()
 
-    # -- public arming / extraction API ------------------------------------
+    # -- public API --------------------------------------------------------
 
-    def arm_request(self, correlation: str, provider: str) -> None:
-        self._armed_request[correlation] = provider
+    async def arm(self, correlation: str) -> None:
+        """Register ``correlation`` before triggering the Portkey call."""
+        self._pending[correlation] = _Pending()
 
-    def take_captured_request(self, correlation: str) -> CapturedRequest:
-        return self._captured.pop(correlation)
+    async def wait_for_capture(self, correlation: str,
+                               timeout: float) -> CapturedRequest:
+        """Wait until Portkey POSTs the translated request.
 
-    def arm_response(self, correlation: str, body: bytes) -> None:
-        self._armed_response[correlation] = body
-
-    def disarm(self, correlation: str) -> None:
-        """Drop any pending state for ``correlation``.
-
-        Called by the callout on error paths (Portkey call failed, capture
-        never happened) so abandoned correlations do not accumulate in a
-        long-running server.
+        Raises ``KeyError`` if the correlation was never armed,
+        ``asyncio.TimeoutError`` if Portkey does not call within ``timeout``,
+        and ``RuntimeError`` if the Portkey call failed before capturing
+        anything (see ``fail``).
         """
-        self._armed_request.pop(correlation, None)
-        self._captured.pop(correlation, None)
-        self._armed_response.pop(correlation, None)
+        pending = self._pending[correlation]
+        await asyncio.wait_for(pending.captured_event.wait(), timeout)
+        if pending.captured is None:
+            raise RuntimeError("Portkey call failed before capture")
+        return pending.captured
 
-    # -- handlers ----------------------------------------------------------
+    async def fail(self, correlation: str) -> None:
+        """Wake a ``wait_for_capture`` waiter without a captured request.
 
-    async def _on_request_capture(self, request: web.Request) -> web.Response:
+        The callout calls this when the Portkey call completes without
+        POSTing here, whether it raised or returned its own error response,
+        so the waiter reports the real cause immediately instead of sitting
+        out the capture timeout. A no-op once a capture has happened.
+        """
+        pending = self._pending.get(correlation)
+        if pending is None:
+            return
+        pending.captured_event.set()
+
+    async def provide_response(self, correlation: str, body: bytes) -> None:
+        """Supply the provider's native response, unparking the connection."""
+        pending = self._pending.get(correlation)
+        if pending is None:
+            return
+        pending.response = body
+        pending.response_event.set()
+
+    async def disarm(self, correlation: str) -> None:
+        """Drop state for ``correlation`` and release any parked connection.
+
+        Called by the callout on error paths so abandoned correlations do not
+        accumulate, and so a parked handler does not wait out the full park
+        timeout when the callout already knows no response is coming.
+
+        Dropping the entry here also covers the case where Portkey never
+        called at all, so no handler will ever run to clean it up. A handler
+        that is parked holds its own reference to the state, so removing it
+        from the map does not disturb it.
+        """
+        pending = self._pending.pop(correlation, None)
+        if pending is None:
+            return
+        # Leave response as None so the parked handler returns an error.
+        pending.response_event.set()
+
+    # -- handler -----------------------------------------------------------
+
+    async def _on_capture(self, request: web.Request) -> web.Response:
         corr = request.headers.get(CORRELATION_HEADER)
-        if corr is None or corr not in self._armed_request:
+        pending = self._pending.get(corr) if corr else None
+        if corr is None or pending is None:
             return web.Response(status=400, text="missing/unknown correlation")
-        provider = self._armed_request.pop(corr)
-        body = await request.read()
-        self._captured[corr] = CapturedRequest(
+
+        pending.captured = CapturedRequest(
             path=request.path_qs,
             headers={k.lower(): v for k, v in request.headers.items()},
-            body=body,
+            body=await request.read(),
         )
-        return web.Response(
-            status=200,
-            body=build_stub_response(provider),
-            content_type="application/json",
-        )
+        pending.captured_event.set()
 
-    async def _on_response_replay(self, request: web.Request) -> web.Response:
-        corr = request.headers.get(CORRELATION_HEADER)
-        if corr is None or corr not in self._armed_response:
-            return web.Response(status=400, text="missing/unknown correlation")
-        body = self._armed_response.pop(corr)
-        return web.Response(
-            status=200, body=body, content_type="application/json")
+        # Park: hold the connection open until the ext_proc response phase
+        # supplies the provider's native response. From Portkey's side this
+        # looks like a provider that is taking its time to answer. The
+        # ``finally`` pop is the single cleanup point for every exit,
+        # including cancellation (server shutdown mid-park, or deployments
+        # that enable aiohttp handler cancellation on client disconnect).
+        try:
+            try:
+                await asyncio.wait_for(pending.response_event.wait(),
+                                       self._park_timeout)
+            except asyncio.TimeoutError:
+                return web.Response(
+                    status=504, text="timed out awaiting provider response")
+
+            body = pending.response
+            if body is None:
+                return web.Response(status=502, text="no provider response")
+            return web.Response(
+                status=200, body=body, content_type="application/json")
+        finally:
+            self._pending.pop(corr, None)

--- a/callouts/python/extproc/example/portkey_gateway/cloudbuild.yaml
+++ b/callouts/python/extproc/example/portkey_gateway/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and pushes the Python ext_proc callout image to Artifact Registry.
+#
+# Submit from callouts/python/:
+#   gcloud builds submit \
+#     --config=extproc/example/portkey_gateway/cloudbuild.yaml \
+#     --project=YOUR_PROJECT_ID
+#
+# The build context is callouts/python/ (the package root).
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/portkey-gateway/callout:latest'
+      - '-f'
+      - 'extproc/example/portkey_gateway/Dockerfile'
+      - '.'
+
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/portkey-gateway/callout:latest'

--- a/callouts/python/extproc/example/portkey_gateway/deploy/terraform/main.tf
+++ b/callouts/python/extproc/example/portkey_gateway/deploy/terraform/main.tf
@@ -1,0 +1,583 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.15.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# ===================================================================
+# ENABLE REQUIRED APIS
+# ===================================================================
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "aiplatform.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "networkservices.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# ===================================================================
+# SERVICE ACCOUNT: CALLOUT
+# ===================================================================
+#
+# The callout uses ADC (via the Cloud Run service identity) to mint Vertex AI
+# bearer tokens. The SA therefore needs roles/aiplatform.user.
+#
+# By default the project's default compute SA is used (has roles/editor).
+# For tighter scoping set var.callout_service_account.
+
+locals {
+  callout_service_account = coalesce(
+    var.callout_service_account,
+    "${data.google_project.project.number}-compute@developer.gserviceaccount.com",
+  )
+
+  api_keys_all = {
+    anthropic  = var.anthropic_api_key
+    groq       = var.groq_api_key
+    openrouter = var.openrouter_api_key
+  }
+  active_providers = nonsensitive(toset([
+    for k, v in local.api_keys_all : k if v != ""
+  ]))
+
+  # Each provider here gets an Internet NEG + backend on the LB. The URL
+  # map matches `prefix=/v1/` + `x-model-id` prefix `<provider>/` to pick the
+  # right backend. Vertex AI is below as a separate resource.
+  third_party_providers = {
+    anthropic  = "api.anthropic.com"
+    groq       = "api.groq.com"
+    openrouter = "openrouter.ai"
+  }
+}
+
+# ===================================================================
+# SECRET MANAGER: PROVIDER API KEYS
+# ===================================================================
+
+resource "google_secret_manager_secret" "api_keys" {
+  for_each  = local.active_providers
+  secret_id = "portkey-gateway-${each.key}-api-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "api_keys" {
+  for_each    = local.active_providers
+  secret      = google_secret_manager_secret.api_keys[each.key].id
+  secret_data = local.api_keys_all[each.key]
+}
+
+resource "google_secret_manager_secret_iam_member" "callout_accessor" {
+  for_each  = local.active_providers
+  secret_id = google_secret_manager_secret.api_keys[each.key].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${local.callout_service_account}"
+}
+
+# ===================================================================
+# CLOUD RUN: CALLOUT (Python ext_proc service)
+# Multi-container: callout (ingress) + Portkey gateway sidecar
+# ===================================================================
+
+resource "google_cloud_run_v2_service" "callout" {
+  name                = "portkey-gateway-callout"
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = local.callout_service_account
+
+    # Ingress container: the Python ext_proc callout. Must be listed first.
+    containers {
+      name  = "callout"
+      image = var.callout_image
+      ports {
+        name           = "h2c"
+        container_port = 8080
+      }
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "GCP_REGION"
+        value = var.region
+      }
+      env {
+        name  = "PORTKEY_BASE_URL"
+        value = "http://127.0.0.1:8787"
+      }
+      dynamic "env" {
+        for_each = local.active_providers
+        content {
+          name = "${upper(env.key)}_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.api_keys[env.key].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+      startup_probe {
+        http_get {
+          path = "/"
+          port = 80
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 3
+      }
+      liveness_probe {
+        http_get {
+          path = "/"
+          port = 80
+        }
+        period_seconds = 10
+      }
+    }
+
+    # Sidecar container: Portkey gateway. Reachable only via localhost from
+    # the callout container. No `ports` block: only the ingress container
+    # declares ports in Cloud Run v2 multi-container.
+    containers {
+      name  = "portkey-sidecar"
+      image = var.portkey_image
+      # Sidecar is reachable only via localhost from the callout container.
+      # Do not declare a `ports` block. Only the ingress container declares ports.
+      env {
+        name  = "PORT"
+        value = "8787"
+      }
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+      }
+    }
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 10
+    }
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_secret_manager_secret_version.api_keys,
+    google_secret_manager_secret_iam_member.callout_accessor,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "callout_public_invoker" {
+  name     = google_cloud_run_v2_service.callout.name
+  location = google_cloud_run_v2_service.callout.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_compute_region_network_endpoint_group" "callout_neg" {
+  name                  = "portkey-gateway-callout-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+  cloud_run {
+    service = google_cloud_run_v2_service.callout.name
+  }
+}
+
+resource "google_compute_backend_service" "callout_backend" {
+  name                  = "portkey-gateway-callout-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTP2"
+  backend {
+    group = google_compute_region_network_endpoint_group.callout_neg.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+# ===================================================================
+# CLOUD RUN: UPSTREAM APPLICATION (non-LLM traffic, e.g., chat UI)
+# ===================================================================
+
+resource "google_cloud_run_v2_service" "upstream_app" {
+  name                = "portkey-gateway-upstream"
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = var.upstream_app_image
+      ports {
+        container_port = 8080
+      }
+    }
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 5
+    }
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "upstream_public_invoker" {
+  name     = google_cloud_run_v2_service.upstream_app.name
+  location = google_cloud_run_v2_service.upstream_app.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_compute_region_network_endpoint_group" "upstream_neg" {
+  name                  = "portkey-gateway-upstream-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+  cloud_run {
+    service = google_cloud_run_v2_service.upstream_app.name
+  }
+}
+
+resource "google_compute_backend_service" "upstream_backend" {
+  name                  = "portkey-gateway-upstream-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  backend {
+    group = google_compute_region_network_endpoint_group.upstream_neg.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+# ===================================================================
+# VERTEX AI BACKEND: GLOBAL INTERNET NEG
+# ===================================================================
+
+resource "google_compute_global_network_endpoint_group" "vertex_neg" {
+  name                  = "portkey-gateway-vertex-neg"
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+  default_port          = 443
+  depends_on            = [google_project_service.apis]
+}
+
+resource "google_compute_global_network_endpoint" "vertex_endpoint" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.vertex_neg.name
+  fqdn                          = "${var.region}-aiplatform.googleapis.com"
+  port                          = 443
+}
+
+resource "google_compute_backend_service" "vertex_backend" {
+  name                  = "portkey-gateway-vertex-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  timeout_sec           = 180
+  backend {
+    group           = google_compute_global_network_endpoint_group.vertex_neg.id
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  depends_on = [google_compute_global_network_endpoint.vertex_endpoint]
+}
+
+# ===================================================================
+# THIRD-PARTY PROVIDER BACKENDS: GLOBAL INTERNET NEGs
+# ===================================================================
+
+resource "google_compute_global_network_endpoint_group" "provider_neg" {
+  for_each              = local.third_party_providers
+  name                  = "portkey-gateway-${each.key}-neg"
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+  default_port          = 443
+  depends_on            = [google_project_service.apis]
+}
+
+resource "google_compute_global_network_endpoint" "provider_endpoint" {
+  for_each                      = local.third_party_providers
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.provider_neg[each.key].name
+  fqdn                          = each.value
+  port                          = 443
+}
+
+resource "google_compute_backend_service" "provider_backend" {
+  for_each              = local.third_party_providers
+  name                  = "portkey-gateway-${each.key}-be"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+  timeout_sec           = 180
+  backend {
+    group           = google_compute_global_network_endpoint_group.provider_neg[each.key].id
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  depends_on = [google_compute_global_network_endpoint.provider_endpoint]
+}
+
+# ===================================================================
+# LOAD BALANCER: GLOBAL EXTERNAL APPLICATION LB
+# ===================================================================
+
+resource "google_compute_global_address" "lb_ip" {
+  name = "portkey-gateway-lb-ip"
+}
+
+resource "tls_private_key" "lb_key" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "lb_cert" {
+  private_key_pem = tls_private_key.lb_key.private_key_pem
+  subject {
+    common_name = "portkey-gateway.example.com"
+  }
+  validity_period_hours = 8760
+  allowed_uses          = ["server_auth"]
+}
+
+resource "google_compute_ssl_certificate" "lb_cert" {
+  name        = "portkey-gateway-cert"
+  private_key = tls_private_key.lb_key.private_key_pem
+  certificate = tls_self_signed_cert.lb_cert.cert_pem
+}
+
+# URL map: model-id prefix routing. The URL map picks the provider backend
+# by matching the client-supplied `x-model-id` header against the provider
+# prefix (the first segment of the model id, e.g. `anthropic/` for
+# `anthropic/claude-3-5-sonnet-...`). The Traffic Extension reads the body,
+# transforms OpenAI to the provider format, and rewrites `:path` for the
+# upstream call. It does NOT influence routing (Traffic Extensions can't
+# switch backends post-decision).
+#
+# So the rules are:
+#   /v1/* + x-model-id prefix `anthropic/`   -> Anthropic backend
+#   /v1/* + x-model-id prefix `groq/`        -> Groq backend
+#   /v1/* + x-model-id prefix `openrouter/`  -> OpenRouter backend
+#   /v1/*                                    -> Vertex AI backend (default)
+#   anything else                            -> upstream sample UI
+resource "google_compute_url_map" "url_map" {
+  name            = "portkey-gateway-url-map"
+  default_service = google_compute_backend_service.upstream_backend.id
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "llm"
+  }
+
+  path_matcher {
+    name            = "llm"
+    default_service = google_compute_backend_service.upstream_backend.id
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-model-id"
+          prefix_match = "anthropic/"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["anthropic"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "api.anthropic.com"
+        }
+      }
+    }
+
+    route_rules {
+      priority = 2
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-model-id"
+          prefix_match = "groq/"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["groq"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "api.groq.com"
+        }
+      }
+    }
+
+    route_rules {
+      priority = 3
+      match_rules {
+        prefix_match = "/v1/"
+        header_matches {
+          header_name  = "x-model-id"
+          prefix_match = "openrouter/"
+        }
+      }
+      service = google_compute_backend_service.provider_backend["openrouter"].id
+      route_action {
+        url_rewrite {
+          host_rewrite = "openrouter.ai"
+        }
+      }
+    }
+
+    # Fallback for /v1/* with no matching x-model-id prefix: Vertex AI.
+    route_rules {
+      priority = 4
+      match_rules {
+        prefix_match = "/v1/"
+      }
+      service = google_compute_backend_service.vertex_backend.id
+      route_action {
+        url_rewrite {
+          host_rewrite = "${var.region}-aiplatform.googleapis.com"
+        }
+      }
+    }
+  }
+}
+
+resource "google_compute_target_https_proxy" "https_proxy" {
+  name             = "portkey-gateway-https-proxy"
+  url_map          = google_compute_url_map.url_map.id
+  ssl_certificates = [google_compute_ssl_certificate.lb_cert.id]
+}
+
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "portkey-gateway-fwd-rule"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.https_proxy.id
+  ip_address            = google_compute_global_address.lb_ip.id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# ===================================================================
+# SERVICE EXTENSIONS: TRAFFIC EXTENSION
+# ===================================================================
+#
+# Traffic Extension on Global LB. The callout sees REQUEST_BODY and does:
+#   1. Body transform OpenAI → provider format (via Portkey gateway sidecar)
+#   2. :path rewrite to the provider-specific path
+#   3. Auth header injection (Authorization for Vertex via ADC, x-api-key
+#      for Anthropic, etc.), all via the Portkey gateway.
+#
+# It does NOT influence routing. Routing was decided by the URL map based on
+# the client's x-model-id header (prefix match on the provider segment).
+
+resource "google_network_services_lb_traffic_extension" "callout" {
+  name                  = "portkey-gateway-traffic-ext"
+  location              = "global"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  forwarding_rules = [
+    google_compute_global_forwarding_rule.forwarding_rule.self_link
+  ]
+  extension_chains {
+    name = "portkey-gateway-chain"
+    match_condition {
+      cel_expression = "request.path in ['/v1/chat/completions', '/v1/completions', '/v1/embeddings']"
+    }
+    extensions {
+      name             = "portkey-gateway-callout"
+      service          = google_compute_backend_service.callout_backend.self_link
+      authority        = "portkey-gateway.example.com"
+      supported_events = ["REQUEST_HEADERS", "REQUEST_BODY", "RESPONSE_HEADERS", "RESPONSE_BODY"]
+      timeout          = "10s"
+    }
+  }
+  depends_on = [google_project_service.apis]
+}
+
+# ===================================================================
+# OUTPUTS
+# ===================================================================
+
+output "load_balancer_ip" {
+  description = "The external IP address of the load balancer."
+  value       = google_compute_global_address.lb_ip.address
+}
+
+output "callout_service_url" {
+  description = "The URL of the Python ext_proc callout Cloud Run service."
+  value       = google_cloud_run_v2_service.callout.uri
+}
+
+output "upstream_service_url" {
+  description = "The URL of the upstream application Cloud Run service."
+  value       = google_cloud_run_v2_service.upstream_app.uri
+}
+
+output "vertex_endpoint" {
+  description = "The Vertex AI FQDN this deployment forwards LLM requests to."
+  value       = "${var.region}-aiplatform.googleapis.com"
+}
+
+output "curl_test_command" {
+  description = "Example curl command to test the Portkey gateway through the load balancer."
+  value       = <<-EOT
+    # Vertex AI (no header needed, default backend)
+    curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{"model": "vertex_ai/gemini-2.5-flash", "messages": [{"role": "user", "content": "Hello"}]}'
+
+    # Anthropic / Groq / OpenRouter: set x-model-id to the full model id.
+    # The URL map matches on the provider prefix (e.g. `anthropic/`).
+    curl -sk -X POST https://${google_compute_global_address.lb_ip.address}/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "x-model-id: anthropic/claude-haiku-4-5" \
+      -d '{"model": "anthropic/claude-haiku-4-5", "messages": [{"role": "user", "content": "Hello"}]}'
+  EOT
+}

--- a/callouts/python/extproc/example/portkey_gateway/deploy/terraform/terraform.tfvars.example
+++ b/callouts/python/extproc/example/portkey_gateway/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy this file to terraform.tfvars and fill in your values.
+
+project_id = "your-gcp-project-id"
+region     = "us-central1"
+
+# Container image. Build and push using cloudbuild.yaml (Python callout).
+callout_image = "us-central1-docker.pkg.dev/YOUR_PROJECT_ID/portkey-gateway/callout:latest"
+
+# Portkey gateway sidecar image. Pin a specific tag for production.
+portkey_image = "portkeyai/gateway:latest"  # pin a specific tag for production
+
+# Upstream app image (receives non-LLM traffic).
+# Defaults to a "Hello, world!" image. Use the sample-ui image to serve the chat interface:
+# upstream_app_image = "us-central1-docker.pkg.dev/your-project/portkey-gateway/sample-ui:latest"
+
+# Email of the service account used by the callout Cloud Run service.
+# Must have roles/aiplatform.user so the Portkey gateway's ADC flow can mint Vertex AI tokens.
+# If empty, the project's default compute SA is used (has roles/editor).
+# callout_service_account = "portkey-gateway-sa@your-project.iam.gserviceaccount.com"
+
+# Provider API keys, only required for the providers you actually use.
+# These are written into Cloud Run env vars; the Portkey gateway reads them automatically.
+# anthropic_api_key  = "my-api-key"
+# groq_api_key       = "my-api-key"
+# openrouter_api_key = "my-api-key"

--- a/callouts/python/extproc/example/portkey_gateway/deploy/terraform/variables.tf
+++ b/callouts/python/extproc/example/portkey_gateway/deploy/terraform/variables.tf
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The Google Cloud project ID where the resources will be created."
+  type        = string
+}
+
+variable "region" {
+  description = "The Google Cloud region for the resources."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "callout_image" {
+  description = "The container image for the Python ext_proc callout service."
+  type        = string
+}
+
+variable "upstream_app_image" {
+  description = "The container image for the upstream application (receives non-LLM traffic)."
+  type        = string
+  default     = "gcr.io/google-samples/hello-app:1.0"
+}
+
+variable "callout_service_account" {
+  description = "Email of the service account used by the callout Cloud Run service. Must have roles/aiplatform.user so the Portkey gateway's ADC flow can mint Vertex AI bearer tokens. If empty, the project's default compute SA is used."
+  type        = string
+  default     = ""
+}
+
+variable "anthropic_api_key" {
+  description = "Anthropic API key. Picked up by the Portkey gateway when the request model starts with 'anthropic/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "groq_api_key" {
+  description = "Groq API key. Picked up by the Portkey gateway when the request model starts with 'groq/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "openrouter_api_key" {
+  description = "OpenRouter API key. Picked up by the Portkey gateway when the request model starts with 'openrouter/'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "portkey_image" {
+  description = "Container image for the Portkey gateway sidecar."
+  type        = string
+  default     = "portkeyai/gateway:latest"
+}

--- a/callouts/python/extproc/example/portkey_gateway/portkey_client.py
+++ b/callouts/python/extproc/example/portkey_gateway/portkey_client.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async HTTP client for the Portkey gateway sidecar.
+
+A single ``translate`` method drives both phases of the loopback. Portkey
+does the same round-trip both times: translate the OpenAI body to provider
+format, POST to ``custom_host``, translate the response back to OpenAI,
+return it. Which loopback endpoint we point ``custom_host`` at decides
+what the caller does with the result.
+
+* **Request phase**: ``custom_host = http://127.0.0.1:9999`` (capture
+  server). We discard the response Portkey returns (the translated stub)
+  and use the bytes the capture endpoint recorded instead.
+
+* **Response phase**: ``custom_host = http://127.0.0.1:9998`` (replay
+  server). The replay endpoint serves the LB-captured provider bytes;
+  Portkey translates them back to OpenAI and returns that to us.
+
+We force ``stream=false`` on the round-trip: we only need translated bytes
+from Portkey, not a streamed response.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from extproc.example.portkey_gateway.capture_server import CORRELATION_HEADER
+
+
+_FORWARD_HEADER = "x-portkey-forward-headers"
+
+
+class PortkeyClient:
+    def __init__(self, base_url: str = "http://127.0.0.1:8787",
+                 timeout: float = 30.0) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def translate(
+        self,
+        *,
+        openai_body: dict,
+        provider: str,
+        api_key: str,
+        custom_host: str,
+        correlation: str,
+        extra_headers: dict[str, str],
+    ) -> httpx.Response:
+        """POST the OpenAI body to Portkey with ``custom_host`` pointing at
+        the appropriate loopback endpoint for the current phase."""
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"Bearer {api_key}",
+            "x-portkey-provider": provider,
+            "x-portkey-custom-host": custom_host,
+            CORRELATION_HEADER: correlation,
+            # Ensure Portkey forwards our correlation header (and any caller-
+            # supplied extras) through to the custom_host so the capture server
+            # can match phases.
+            _FORWARD_HEADER: ",".join(
+                sorted({CORRELATION_HEADER, *extra_headers.keys()})),
+            **extra_headers,
+        }
+        body = dict(openai_body, stream=False)
+        return await self._client.post(
+            "/v1/chat/completions",
+            content=json.dumps(body),
+            headers=headers,
+        )

--- a/callouts/python/extproc/example/portkey_gateway/portkey_client.py
+++ b/callouts/python/extproc/example/portkey_gateway/portkey_client.py
@@ -14,19 +14,16 @@
 
 """Async HTTP client for the Portkey gateway sidecar.
 
-A single ``translate`` method drives both phases of the loopback. Portkey
-does the same round-trip both times: translate the OpenAI body to provider
-format, POST to ``custom_host``, translate the response back to OpenAI,
-return it. Which loopback endpoint we point ``custom_host`` at decides
-what the caller does with the result.
+One ``translate`` call covers both ext_proc phases. Portkey translates the
+OpenAI body to provider format, POSTs it to ``custom_host`` (the capture
+server), and blocks there until the capture server writes a response. The
+callout reads the translated request as soon as it is captured, and only
+supplies the response later, once the provider has answered through the LB.
+The call therefore stays open across the request and response phases, and
+resolves with Portkey's OpenAI-shaped translation of the real response.
 
-* **Request phase**: ``custom_host = http://127.0.0.1:9999`` (capture
-  server). We discard the response Portkey returns (the translated stub)
-  and use the bytes the capture endpoint recorded instead.
-
-* **Response phase**: ``custom_host = http://127.0.0.1:9998`` (replay
-  server). The replay endpoint serves the LB-captured provider bytes;
-  Portkey translates them back to OpenAI and returns that to us.
+Because a single call spans the whole upstream round-trip, ``timeout`` must
+exceed the LB backend timeout (``timeout_sec`` in deploy/terraform/main.tf).
 
 We force ``stream=false`` on the round-trip: we only need translated bytes
 from Portkey, not a streamed response.
@@ -46,7 +43,7 @@ _FORWARD_HEADER = "x-portkey-forward-headers"
 
 class PortkeyClient:
     def __init__(self, base_url: str = "http://127.0.0.1:8787",
-                 timeout: float = 30.0) -> None:
+                 timeout: float = 300.0) -> None:
         self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
 
     async def close(self) -> None:
@@ -63,7 +60,7 @@ class PortkeyClient:
         extra_headers: dict[str, str],
     ) -> httpx.Response:
         """POST the OpenAI body to Portkey with ``custom_host`` pointing at
-        the appropriate loopback endpoint for the current phase."""
+        the capture server. Resolves once the capture server unparks."""
         headers = {
             "content-type": "application/json",
             "authorization": f"Bearer {api_key}",

--- a/callouts/python/extproc/example/portkey_gateway/sample-ui/Dockerfile
+++ b/callouts/python/extproc/example/portkey_gateway/sample-ui/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 8080
+RUN sed -i 's/listen\s*80;/listen 8080;/' /etc/nginx/conf.d/default.conf

--- a/callouts/python/extproc/example/portkey_gateway/sample-ui/cloudbuild.yaml
+++ b/callouts/python/extproc/example/portkey_gateway/sample-ui/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/portkey-gateway/sample-ui:latest'
+      - '.'
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/portkey-gateway/sample-ui:latest'

--- a/callouts/python/extproc/example/portkey_gateway/sample-ui/index.html
+++ b/callouts/python/extproc/example/portkey_gateway/sample-ui/index.html
@@ -1,0 +1,638 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2026 Google LLC.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Portkey Gateway Demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f0f2f5;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      background: #1a73e8;
+      color: white;
+      padding: 12px 20px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      flex: 1;
+    }
+
+    .header-controls label {
+      font-size: 13px;
+      font-weight: 500;
+    }
+
+    .header-controls select,
+    .header-controls input {
+      padding: 6px 10px;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      background: rgba(255,255,255,0.15);
+      color: white;
+      outline: none;
+    }
+
+    .header-controls select option { color: #333; background: white; }
+    .header-controls input::placeholder { color: rgba(255,255,255,0.5); }
+    .header-controls select:focus,
+    .header-controls input:focus { background: rgba(255,255,255,0.25); }
+
+    .status-badge {
+      font-size: 12px;
+      padding: 4px 10px;
+      border-radius: 12px;
+      font-weight: 500;
+      margin-left: auto;
+    }
+
+    .status-badge.connected { background: #34a853; }
+    .status-badge.error { background: #ea4335; }
+    .status-badge.loading { background: #fbbc04; color: #333; }
+
+    #chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .message {
+      max-width: 75%;
+      padding: 12px 16px;
+      border-radius: 16px;
+      font-size: 14px;
+      line-height: 1.6;
+      word-wrap: break-word;
+    }
+
+    .message.user {
+      align-self: flex-end;
+      background: #1a73e8;
+      color: white;
+      border-bottom-right-radius: 4px;
+      white-space: pre-wrap;
+    }
+
+    .message.assistant {
+      align-self: flex-start;
+      background: white;
+      color: #333;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+
+    .message.assistant h1,
+    .message.assistant h2,
+    .message.assistant h3 {
+      margin: 12px 0 6px 0;
+      font-weight: 600;
+    }
+    .message.assistant h1 { font-size: 1.3em; }
+    .message.assistant h2 { font-size: 1.15em; }
+    .message.assistant h3 { font-size: 1.05em; }
+    .message.assistant h1:first-child,
+    .message.assistant h2:first-child,
+    .message.assistant h3:first-child { margin-top: 0; }
+
+    .message.assistant p { margin: 8px 0; }
+    .message.assistant p:first-child { margin-top: 0; }
+    .message.assistant p:last-child { margin-bottom: 0; }
+
+    .message.assistant ul,
+    .message.assistant ol {
+      margin: 8px 0;
+      padding-left: 20px;
+    }
+
+    .message.assistant li { margin: 4px 0; }
+
+    .message.assistant code {
+      background: #f1f3f4;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+      font-family: 'Consolas', 'Monaco', monospace;
+    }
+
+    .message.assistant pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 12px 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 10px 0;
+      font-size: 0.85em;
+      line-height: 1.5;
+    }
+
+    .message.assistant pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+      font-size: inherit;
+    }
+
+    .message.assistant blockquote {
+      border-left: 3px solid #1a73e8;
+      padding: 4px 12px;
+      margin: 8px 0;
+      color: #555;
+      background: #f8f9fa;
+      border-radius: 0 6px 6px 0;
+    }
+
+    .message.assistant hr {
+      border: none;
+      border-top: 1px solid #e0e0e0;
+      margin: 12px 0;
+    }
+
+    .message.assistant strong { font-weight: 600; }
+    .message.assistant em { font-style: italic; }
+
+    .message.error {
+      align-self: flex-start;
+      background: #fce8e6;
+      color: #c5221f;
+      border-bottom-left-radius: 4px;
+      white-space: pre-wrap;
+    }
+
+    .message.thinking {
+      align-self: flex-start;
+      background: white;
+      color: #999;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+
+    .thinking-dots span {
+      animation: blink 1.4s infinite both;
+    }
+    .thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+    .thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+    @keyframes blink {
+      0%, 80%, 100% { opacity: 0.3; }
+      40% { opacity: 1; }
+    }
+
+    #resizer {
+      height: 6px;
+      background: #e0e0e0;
+      cursor: ns-resize;
+      flex-shrink: 0;
+      position: relative;
+      transition: background 0.15s;
+    }
+
+    #resizer:hover,
+    #resizer.active { background: #1a73e8; }
+
+    #resizer::after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 36px;
+      height: 3px;
+      border-radius: 2px;
+      background: rgba(0,0,0,0.2);
+    }
+
+    #resizer:hover::after,
+    #resizer.active::after { background: rgba(255,255,255,0.6); }
+
+    #chat-form {
+      padding: 12px 20px;
+      background: white;
+      display: flex;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    #user-input {
+      flex: 1;
+      height: 100%;
+      padding: 12px 16px;
+      border: 1px solid #ddd;
+      border-radius: 16px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: none;
+      outline: none;
+    }
+
+    #user-input:focus { border-color: #1a73e8; }
+
+    #send-button {
+      padding: 0 24px;
+      background: #1a73e8;
+      color: white;
+      border: none;
+      border-radius: 24px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    #send-button:hover { background: #1557b0; }
+    #send-button:disabled { background: #ccc; cursor: not-allowed; }
+
+    footer {
+      padding: 8px 20px;
+      background: #fafafa;
+      border-top: 1px solid #e0e0e0;
+      font-size: 12px;
+      color: #666;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .welcome {
+      text-align: center;
+      color: #999;
+      padding: 40px 20px;
+      font-size: 14px;
+    }
+
+    .welcome h2 {
+      font-size: 20px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Portkey Gateway Demo</h1>
+    <div class="header-controls">
+      <label for="model-select">Model:</label>
+      <select id="model-select" data-testid="model-select" disabled>
+        <option value="">Loading models...</option>
+      </select>
+    </div>
+    <input id="api-key" data-testid="api-key" type="hidden" value="sk-test-master-key">
+    <span id="status" class="status-badge loading" data-testid="status">Connecting...</span>
+  </header>
+
+  <div id="chat-messages" data-testid="chat-messages">
+    <div class="welcome">
+      <h2>Welcome</h2>
+      <p>Select a model above and start chatting.</p>
+    </div>
+  </div>
+
+  <div id="resizer" data-testid="resizer"></div>
+
+  <form id="chat-form" style="height: 80px;">
+    <textarea id="user-input" data-testid="user-input" placeholder="Type a message..." disabled></textarea>
+    <button id="send-button" data-testid="send-button" type="submit" disabled>Send</button>
+  </form>
+
+  <footer>
+    <span id="metadata" data-testid="metadata">No messages yet</span>
+    <span>Powered by Service Extensions + Portkey</span>
+  </footer>
+
+  <script>
+    const state = {
+      apiBase: '',
+      apiKey: '',
+      messages: [],
+      selectedModel: '',
+      sending: false,
+    };
+
+    function getApiBase() {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('api')) return params.get('api').replace(/\/+$/, '');
+      if (window.PORTKEY_API_BASE) return window.PORTKEY_API_BASE.replace(/\/+$/, '');
+      // When served from the same domain (e.g. behind the ALB), use
+      // relative paths. The localhost fallback is only useful if you point
+      // it at your own OpenAI-compatible server; this sample has no
+      // local-dev path (see the README).
+      if (window.location.protocol === 'https:') return '';
+      return 'http://localhost:4000';
+    }
+
+    function getApiKey() {
+      return document.getElementById('api-key').value.trim();
+    }
+
+    function buildHeaders() {
+      const headers = { 'Content-Type': 'application/json' };
+      const key = getApiKey();
+      if (key) headers['Authorization'] = 'Bearer ' + key;
+      // Routing signal: the LB's URL map uses prefix_match on this header
+      // to pick the correct provider backend. The value is the full model
+      // id (e.g. "anthropic/claude-..."); the URL map matches on the
+      // provider prefix (e.g. "anthropic/").
+      if (state.selectedModel) {
+        headers['x-model-id'] = state.selectedModel;
+      }
+      return headers;
+    }
+
+    // Models are defined here rather than fetched from /v1/models, since the Python
+    // callout fronts a self-hosted Portkey sidecar so /v1/models is not implemented.
+    // Each entry is a <provider>/<model> id (the callout strips the provider
+    // prefix before forwarding to Portkey). For OpenRouter
+    // (an aggregator), the model id includes the upstream publisher prefix,
+    // e.g. openrouter/openai/gpt-oss-20b:free.
+    var AVAILABLE_MODELS = [
+      'vertex_ai/gemini-2.5-flash',
+      'vertex_ai/gemini-2.5-pro',
+      'anthropic/claude-haiku-4-5',
+      'groq/compound-beta',
+      'openrouter/openai/gpt-oss-20b:free',
+    ];
+
+    function fetchModels() {
+      const statusEl = document.getElementById('status');
+      const selectEl = document.getElementById('model-select');
+
+      selectEl.innerHTML = '';
+      AVAILABLE_MODELS.forEach(function(id) {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = id;
+        selectEl.appendChild(opt);
+      });
+
+      state.selectedModel = AVAILABLE_MODELS[0];
+      selectEl.disabled = false;
+      document.getElementById('user-input').disabled = false;
+      document.getElementById('send-button').disabled = false;
+      statusEl.textContent = 'Connected';
+      statusEl.className = 'status-badge connected';
+    }
+
+    // Lightweight markdown to HTML converter.
+    function markdownToHtml(md) {
+      // Escape HTML entities first.
+      var html = md
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
+      // Fenced code blocks: ```lang\n...\n```
+      html = html.replace(/```(\w*)\n([\s\S]*?)```/g, function(_, lang, code) {
+        return '<pre><code>' + code.replace(/\n$/, '') + '</code></pre>';
+      });
+
+      // Inline code: `...`
+      html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+      // Headings: ### ... (process line by line).
+      html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+      html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+      html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+      // Horizontal rules: --- or ***
+      html = html.replace(/^(-{3,}|\*{3,})$/gm, '<hr>');
+
+      // Blockquotes: > ...
+      html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+
+      // Bold: **...**
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+
+      // Italic: *...*
+      html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+      // Unordered lists: convert consecutive "* " or "- " lines.
+      html = html.replace(/(^[\t ]*[*\-] .+$(\n|$))+/gm, function(block) {
+        var items = block.trim().split('\n').map(function(line) {
+          return '<li>' + line.replace(/^[\t ]*[*\-] /, '') + '</li>';
+        }).join('');
+        return '<ul>' + items + '</ul>';
+      });
+
+      // Ordered lists: consecutive "1. " lines.
+      html = html.replace(/(^\d+\. .+$(\n|$))+/gm, function(block) {
+        var items = block.trim().split('\n').map(function(line) {
+          return '<li>' + line.replace(/^\d+\. /, '') + '</li>';
+        }).join('');
+        return '<ol>' + items + '</ol>';
+      });
+
+      // Paragraphs: double newlines become paragraph breaks.
+      // Split on double newlines, wrap non-tag content in <p>.
+      html = html.split(/\n{2,}/).map(function(block) {
+        block = block.trim();
+        if (!block) return '';
+        // Don't wrap blocks that already start with a block-level tag.
+        if (/^<(h[1-3]|pre|ul|ol|blockquote|hr|p)/.test(block)) return block;
+        return '<p>' + block.replace(/\n/g, '<br>') + '</p>';
+      }).join('\n');
+
+      return html;
+    }
+
+    function renderMessage(role, content) {
+      const container = document.getElementById('chat-messages');
+      // Remove welcome message on first interaction.
+      const welcome = container.querySelector('.welcome');
+      if (welcome) welcome.remove();
+
+      const div = document.createElement('div');
+      div.className = 'message ' + role;
+      div.setAttribute('data-testid', 'message-' + role);
+
+      if (role === 'assistant') {
+        div.innerHTML = markdownToHtml(content);
+      } else {
+        div.textContent = content;
+      }
+
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+      return div;
+    }
+
+    function showThinking() {
+      const container = document.getElementById('chat-messages');
+      const div = document.createElement('div');
+      div.className = 'message thinking';
+      div.id = 'thinking-indicator';
+      div.innerHTML = '<span class="thinking-dots"><span>.</span><span>.</span><span>.</span></span>';
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+    }
+
+    function hideThinking() {
+      const el = document.getElementById('thinking-indicator');
+      if (el) el.remove();
+    }
+
+    function updateMetadata(usage, latencyMs, model) {
+      const el = document.getElementById('metadata');
+      const parts = ['Model: ' + model];
+      if (usage) {
+        parts.push(
+          'Tokens: ' + (usage.prompt_tokens || 0) + ' in / ' +
+          (usage.completion_tokens || 0) + ' out / ' +
+          (usage.total_tokens || 0) + ' total'
+        );
+      }
+      parts.push('Latency: ' + latencyMs + 'ms');
+      el.textContent = parts.join('  |  ');
+    }
+
+    async function sendMessage(userText) {
+      if (state.sending || !userText.trim()) return;
+      state.sending = true;
+
+      const input = document.getElementById('user-input');
+      const button = document.getElementById('send-button');
+      input.disabled = true;
+      button.disabled = true;
+
+      state.messages.push({ role: 'user', content: userText.trim() });
+      renderMessage('user', userText.trim());
+      showThinking();
+
+      const startTime = performance.now();
+
+      try {
+        const resp = await fetch(state.apiBase + '/v1/chat/completions', {
+          method: 'POST',
+          headers: buildHeaders(),
+          body: JSON.stringify({
+            model: state.selectedModel,
+            messages: state.messages,
+            stream: false,
+          }),
+        });
+
+        const latencyMs = Math.round(performance.now() - startTime);
+        hideThinking();
+
+        if (!resp.ok) {
+          const errBody = await resp.text();
+          throw new Error('HTTP ' + resp.status + ': ' + errBody);
+        }
+
+        const data = await resp.json();
+        if (!data.choices || !data.choices[0]) {
+          throw new Error('Unexpected response: ' + JSON.stringify(data).substring(0, 600));
+        }
+        const assistantContent = data.choices[0].message.content;
+
+        state.messages.push({ role: 'assistant', content: assistantContent });
+        renderMessage('assistant', assistantContent);
+        updateMetadata(data.usage, latencyMs, data.model || state.selectedModel);
+      } catch (err) {
+        hideThinking();
+        renderMessage('error', 'Error: ' + err.message);
+        // Remove the failed user message from history so conversation stays consistent.
+        state.messages.pop();
+      }
+
+      state.sending = false;
+      input.disabled = false;
+      button.disabled = false;
+      input.focus();
+    }
+
+    // --- Event Listeners ---
+
+    document.getElementById('chat-form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      var input = document.getElementById('user-input');
+      sendMessage(input.value);
+      input.value = '';
+    });
+
+    document.getElementById('user-input').addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        document.getElementById('chat-form').dispatchEvent(new Event('submit'));
+      }
+    });
+
+    document.getElementById('model-select').addEventListener('change', function() {
+      state.selectedModel = this.value;
+    });
+
+    // --- Resizer drag logic ---
+    (function() {
+      var resizer = document.getElementById('resizer');
+      var form = document.getElementById('chat-form');
+      var startY, startHeight;
+
+      resizer.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        startY = e.clientY;
+        startHeight = form.offsetHeight;
+        resizer.classList.add('active');
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+      });
+
+      function onMouseMove(e) {
+        var delta = startY - e.clientY;
+        var newHeight = Math.min(Math.max(startHeight + delta, 60), window.innerHeight * 0.5);
+        form.style.height = newHeight + 'px';
+      }
+
+      function onMouseUp() {
+        resizer.classList.remove('active');
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      }
+    })();
+
+    // --- Init ---
+
+    state.apiBase = getApiBase();
+    state.apiKey = getApiKey();
+    fetchModels();
+  </script>
+</body>
+</html>

--- a/callouts/python/extproc/example/portkey_gateway/service_callout_example.py
+++ b/callouts/python/extproc/example/portkey_gateway/service_callout_example.py
@@ -1,0 +1,599 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Portkey Gateway callout: sidecar + custom_host loopback adapter.
+
+* The callout receives a vanilla OpenAI request from the LB.
+* Sends it to the Portkey sidecar (``localhost:8787``) with
+  ``x-portkey-custom-host: http://localhost:9999`` and the provider API key.
+* Portkey translates OpenAI -> provider format and POSTs to ``:9999``, where
+  the callout's capture server records the translated bytes/headers/path.
+* The callout returns the captured provider-native bytes to the LB as ext_proc
+  mutations; the LB forwards to the provider Internet NEG selected by the URL
+  map's ``header_matches: x-model-id`` (prefix match on the provider segment).
+* On the response, the LB delivers the provider-native response back; the
+  callout arms ``:9998`` with those bytes, calls Portkey again with
+  ``x-portkey-custom-host: http://localhost:9998``, and returns Portkey's
+  OpenAI-shaped translation to the LB.
+
+Routing model: the LB's URL map picks the provider backend from the
+``x-model-id`` header *before* this callout fires.
+The URL map uses a ``prefix_match`` on the provider segment (for example
+``anthropic/`` for ``x-model-id: anthropic/claude-...``). This callout never
+switches backends; it only mutates the body and headers.
+
+Body handling: the callout requests ``BUFFERED`` body delivery via
+``mode_override`` on the request-headers response, but the GCLB Traffic
+Extension data plane keeps response bodies STREAMED, so providers that flush
+in several pieces (for example OpenRouter's keep-alive padding) arrive as
+multiple chunks. ``on_response_body`` therefore buffers chunks (clearing each
+from the egress) and translates the reassembled body on the final chunk.
+Client streaming (``stream: true``) is explicitly rejected with HTTP 501.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import logging
+import os
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, NamedTuple
+
+import google.auth
+import google.auth.transport.requests
+from grpc import ServicerContext
+
+from envoy.config.core.v3.base_pb2 import HeaderValue, HeaderValueOption
+from envoy.extensions.filters.http.ext_proc.v3.processing_mode_pb2 import (
+    ProcessingMode,
+)
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.type.v3.http_status_pb2 import StatusCode
+
+from extproc.service import callout_server
+from extproc.service import callout_tools
+from extproc.example.portkey_gateway import capture_server, portkey_client
+
+# ---------------------------------------------------------------------------
+# Provider registry
+#
+# Maps the ``provider/model`` id's provider prefix onto Portkey's provider
+# identifier, the Internet NEG hostname, and the API-key env var name. Add a
+# provider here and the rest of the callout picks it up automatically.
+# ---------------------------------------------------------------------------
+
+
+class ProviderSpec(NamedTuple):
+    # Value for the x-portkey-provider header.
+    portkey_id: str
+    # :authority for the LB-forwarded request; may contain "{region}".
+    api_base_host: str
+    # Env var holding the API key; None for Vertex AI (uses ADC).
+    api_key_env: str | None
+    # Path prefix to prepend to the path Portkey POSTs to ``custom_host``.
+    # Portkey strips each provider's URL prefix when forwarding to custom_host
+    # (e.g. "/messages" for Anthropic instead of "/v1/messages"). We add the
+    # prefix back so the request the LB forwards reaches the provider's actual
+    # endpoint. Vertex AI is special: Portkey emits the full path including
+    # the project/region segments, so no prefix is needed there.
+    api_path_prefix: str = ""
+    # Default for the ``max_tokens`` field when the client omits it. OpenAI
+    # clients usually do (the OpenAI API treats it as optional), but
+    # Anthropic's Messages API requires it.
+    default_max_tokens: int | None = None
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "anthropic": ProviderSpec(
+        portkey_id="anthropic",
+        api_base_host="api.anthropic.com",
+        api_key_env="ANTHROPIC_API_KEY",
+        api_path_prefix="/v1",        # "/messages" -> "/v1/messages"
+        default_max_tokens=4096,
+    ),
+    "vertex_ai": ProviderSpec(
+        portkey_id="vertex-ai",
+        api_base_host="{region}-aiplatform.googleapis.com",
+        api_key_env=None,
+        # Portkey emits the full /v1/projects/... path; no prefix needed.
+        api_path_prefix="",
+    ),
+    "groq": ProviderSpec(
+        portkey_id="groq",
+        api_base_host="api.groq.com",
+        api_key_env="GROQ_API_KEY",
+        # "/chat/completions" -> "/openai/v1/chat/completions"
+        api_path_prefix="/openai/v1",
+    ),
+    "openrouter": ProviderSpec(
+        portkey_id="openrouter",
+        api_base_host="openrouter.ai",
+        api_key_env="OPENROUTER_API_KEY",
+        # "/v1/chat/completions" -> "/api/v1/chat/completions"
+        api_path_prefix="/api",
+    ),
+}
+
+
+def detect_provider_from_model(model: str) -> tuple[str, str]:
+    """Split a ``provider/model`` id into ``(provider, model_name)``.
+
+    The first ``/`` segment is the provider; the remainder is the model name.
+    OpenRouter intentionally keeps its inner ``/`` (e.g.
+    ``openrouter/openai/gpt-oss-20b:free`` -> provider ``openrouter``, model
+    ``openai/gpt-oss-20b:free``). When no provider prefix is given, defaults
+    to ``vertex_ai`` to match the URL map's fallthrough behaviour.
+    """
+    if "/" in model:
+        provider, _, model_name = model.partition("/")
+        return provider, model_name
+    return "vertex_ai", model
+
+
+def get_api_key(provider: str) -> str | None:
+    """Return the provider's API key env-var value (None for Vertex AI)."""
+    spec = PROVIDERS.get(provider)
+    if spec is None or spec.api_key_env is None:
+        return None
+    return os.getenv(spec.api_key_env)
+
+
+# ---------------------------------------------------------------------------
+# Vertex AI ADC bearer-token helper
+#
+# The Cloud Run service identity supplies Application Default Credentials; we
+# mint an access token from those and pass it as ``Authorization: Bearer
+# <token>`` to Portkey (with ``x-portkey-provider: vertex-ai``). Portkey
+# treats the token as the provider's auth header and forwards it to
+# ``aiplatform.googleapis.com``.
+#
+# The minted token is short-lived. ``mint_adc_token`` refreshes on demand;
+# ``google.auth.transport.requests.Request().refresh(creds)`` mutates the
+# same ``Credentials`` object in place, so callers can call this every
+# request cheaply. (``google.auth`` caches under the hood.)
+# ---------------------------------------------------------------------------
+
+_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
+
+def _load_default_credentials():
+    """Indirection so tests can patch the credentials source."""
+    creds, _ = google.auth.default(scopes=_SCOPES)
+    return creds
+
+
+def mint_adc_token() -> str:
+    """Return a valid ADC access token, refreshing if expired."""
+    creds = _load_default_credentials()
+    if not creds.valid:
+        creds.refresh(google.auth.transport.requests.Request())
+    return creds.token
+
+
+# ---------------------------------------------------------------------------
+# Callout constants and implementation
+# ---------------------------------------------------------------------------
+
+HEADER_PORTKEY_ROUTED = "x-portkey-routed"
+HEADER_PORTKEY_PROVIDER = "x-portkey-provider-stamp"
+HEADER_PORTKEY_MODEL = "x-portkey-model-stamp"
+
+# LLM endpoints the callout transforms. Only /v1/* paths are listed: the
+# URL map's provider route rules match on the /v1/ prefix, so only these
+# paths can reach a provider backend. The Traffic Extension CEL match in
+# deploy/terraform/main.tf mirrors this list.
+LLM_ENDPOINTS = frozenset({
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+})
+
+_MANAGED_HEADERS = frozenset({
+    "host", ":authority", ":path", "content-length", "content-type",
+})
+
+# Browser-identifying request headers stripped from LLM requests. The LB
+# forwards provider-native requests server-to-server; leaking these upstream
+# misrepresents the request, and Anthropic rejects requests carrying an
+# Origin header outright ("CORS requests must set
+# 'anthropic-dangerous-direct-browser-access'").
+_BROWSER_HEADERS = (
+    "origin",
+    "referer",
+    "cookie",
+    "sec-fetch-site",
+    "sec-fetch-mode",
+    "sec-fetch-dest",
+    "sec-fetch-user",
+    "sec-ch-ua",
+    "sec-ch-ua-mobile",
+    "sec-ch-ua-platform",
+)
+
+
+@dataclass
+class _StreamState:
+    is_llm: bool = False
+    provider: str | None = None
+    correlation: str = ""
+    request_body: dict[str, Any] = field(default_factory=dict)
+    # Response-body chunks accumulated across STREAMED ext_proc messages.
+    response_chunks: list[bytes] = field(default_factory=list)
+
+
+def _state(context: ServicerContext) -> _StreamState:
+    state = getattr(context, "_portkey_state", None)
+    if state is None:
+        state = _StreamState()
+        context._portkey_state = state
+    return state
+
+
+class PortkeyGatewayCallout(callout_server.CalloutServer):
+    """ext_proc adapter that uses Portkey-as-sidecar for translation only."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.gcp_project = os.getenv("GCP_PROJECT_ID", "")
+        self.gcp_region = os.getenv("GCP_REGION", "us-central1")
+        self.portkey_url = os.getenv(
+            "PORTKEY_BASE_URL", "http://127.0.0.1:8787")
+
+        self._capture_request_port = int(
+            os.getenv("CAPTURE_REQUEST_PORT", "9999"))
+        self._capture_response_port = int(
+            os.getenv("CAPTURE_RESPONSE_PORT", "9998"))
+
+        # The capture server and Portkey client are spun up lazily on a worker
+        # thread because the gRPC server runs on its own thread pool and we
+        # need an asyncio event loop to host both.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._capture: capture_server.CaptureServer | None = None
+        self._client: portkey_client.PortkeyClient | None = None
+        self._start_async_components()
+
+    # ---------------- async runtime in a worker thread ----------------
+
+    def _start_async_components(self) -> None:
+        loop_ready = threading.Event()
+
+        def runner():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+            self._capture = capture_server.CaptureServer(
+                request_port=self._capture_request_port,
+                response_port=self._capture_response_port,
+            )
+            self._client = portkey_client.PortkeyClient(
+                base_url=self.portkey_url)
+            loop.run_until_complete(self._capture.start())
+            loop_ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                loop.run_until_complete(self._capture.stop())
+                loop.run_until_complete(self._client.close())
+                loop.close()
+
+        threading.Thread(
+            target=runner, name="portkey-async", daemon=True).start()
+        if not loop_ready.wait(timeout=10):
+            raise RuntimeError("async runtime failed to start within 10s")
+        if self._capture is None or self._client is None:
+            raise RuntimeError("async components missing after loop start")
+
+    def _run_async(self, coro):
+        # self._loop is guaranteed non-None once __init__ returns.
+        future = asyncio.run_coroutine_threadsafe(
+            coro, self._loop)  # type: ignore[arg-type]
+        # Timeout so a hung sidecar surfaces as concurrent.futures.TimeoutError
+        # rather than hanging the gRPC thread indefinitely.
+        return future.result(timeout=30)
+
+    # ---------------- ext_proc phases ----------------
+
+    def on_request_headers(
+        self,
+        headers: service_pb2.HttpHeaders,
+        context: ServicerContext,
+    ) -> service_pb2.ProcessingResponse | None:
+        path = ""
+        for h in headers.headers.headers:
+            if h.key == ":path":
+                path = h.raw_value.decode("utf-8")
+                break
+        if path not in LLM_ENDPOINTS:
+            return None
+        state = _state(context)
+        state.is_llm = True
+        state.correlation = uuid.uuid4().hex
+        logging.info("Routed LLM request path=%s correlation=%s",
+                     path, state.correlation)
+        # A full ProcessingResponse (not a HeadersResponse) because
+        # mode_override lives on the outer message and Envoy only honors it
+        # on the request-headers response. BUFFERED delivery is required:
+        # some providers (e.g. OpenRouter) flush response bodies in several
+        # chunks, and the translation needs the complete body at once.
+        resp = service_pb2.ProcessingResponse()
+        resp.request_headers.response.header_mutation.set_headers.append(
+            HeaderValueOption(header=HeaderValue(
+                key=HEADER_PORTKEY_ROUTED, raw_value=b"true")))
+        resp.request_headers.response.header_mutation.remove_headers.extend(
+            _BROWSER_HEADERS)
+        resp.mode_override.request_body_mode = ProcessingMode.BUFFERED
+        resp.mode_override.response_body_mode = ProcessingMode.BUFFERED
+        return resp
+
+    def on_request_body(
+        self,
+        body: service_pb2.HttpBody,
+        context: ServicerContext,
+    ) -> service_pb2.BodyResponse | service_pb2.ImmediateResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return None
+        raw = body.body
+        if not raw:
+            logging.warning(
+                "Empty request body on LLM endpoint (corr=%s); passing through "
+                "unchanged. This is unexpected for /v1/chat/completions etc.",
+                state.correlation,
+            )
+            return service_pb2.BodyResponse()
+
+        try:
+            req_map = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logging.warning("Invalid JSON body: %s", e)
+            return callout_tools.header_immediate_response(
+                StatusCode.BadRequest)
+
+        if req_map.get("stream"):
+            logging.info(
+                "Streaming not yet supported by portkey_gateway sample")
+            return callout_tools.header_immediate_response(
+                StatusCode.NotImplemented)
+
+        model = req_map.get("model")
+        if not isinstance(model, str) or not model:
+            return callout_tools.header_immediate_response(
+                StatusCode.BadRequest)
+
+        provider, model_name = detect_provider_from_model(model)
+        spec = PROVIDERS.get(provider)
+        if spec is None:
+            return callout_tools.header_immediate_response(
+                StatusCode.BadRequest)
+
+        state.provider = provider
+        state.request_body = dict(req_map, model=model_name)
+        if (spec.default_max_tokens is not None
+                and "max_tokens" not in state.request_body):
+            state.request_body["max_tokens"] = spec.default_max_tokens
+
+        try:
+            api_key, extra_headers = self._auth_for(provider)
+        except Exception:
+            logging.exception("auth setup failed")
+            return callout_tools.header_immediate_response(
+                StatusCode.InternalServerError)
+
+        if self._capture is None or self._client is None:
+            raise RuntimeError("async components not initialized")
+        self._capture.arm_request(state.correlation, provider)
+        custom_host = f"http://127.0.0.1:{self._capture.request_port}"
+        try:
+            self._run_async(self._client.translate(
+                openai_body=state.request_body,
+                provider=spec.portkey_id,
+                api_key=api_key,
+                custom_host=custom_host,
+                correlation=state.correlation,
+                extra_headers=extra_headers,
+            ))
+        except Exception:
+            logging.exception("Portkey request-translation call failed")
+            self._capture.disarm(state.correlation)
+            return callout_tools.header_immediate_response(
+                StatusCode.BadGateway)
+
+        try:
+            captured = self._capture.take_captured_request(state.correlation)
+        except KeyError:
+            logging.error(
+                "Portkey did not POST to capture server (corr=%s)",
+                state.correlation,
+            )
+            self._capture.disarm(state.correlation)
+            return callout_tools.header_immediate_response(
+                StatusCode.BadGateway)
+
+        body_resp = service_pb2.BodyResponse()
+        body_resp.response.body_mutation.body = captured.body
+
+        authority = spec.api_base_host.format(region=self.gcp_region)
+        # Reattach the provider URL prefix Portkey stripped (see ProviderSpec).
+        full_path = spec.api_path_prefix + captured.path
+        rewrites: list[tuple[str, str]] = [
+            (":path", full_path),
+            (":authority", authority),
+            ("host", authority),
+            ("content-type", "application/json"),
+            ("content-length", str(len(captured.body))),
+            ("accept-encoding", "identity"),
+            ("user-agent", "portkey-gateway/1.0"),
+            (HEADER_PORTKEY_PROVIDER, spec.portkey_id),
+            (HEADER_PORTKEY_MODEL, model_name),
+        ]
+        for k, v in captured.headers.items():
+            kl = k.lower()
+            if kl in _MANAGED_HEADERS:
+                continue
+            if kl.startswith("x-portkey-"):
+                continue  # internal; don't leak to the provider
+            rewrites.append((kl, v))
+
+        for k, v in rewrites:
+            body_resp.response.header_mutation.set_headers.append(
+                HeaderValueOption(
+                    header=HeaderValue(key=k, raw_value=v.encode("utf-8")),
+                    append_action=HeaderValueOption.OVERWRITE_IF_EXISTS_OR_ADD,
+                ))
+        return body_resp
+
+    def _auth_for(self, provider: str) -> tuple[str, dict[str, str]]:
+        if provider == "vertex_ai":
+            if not self.gcp_project:
+                logging.warning(
+                    "GCP_PROJECT_ID is not set; Vertex AI requests will fail "
+                    "upstream with an opaque error. Set GCP_PROJECT_ID on the "
+                    "callout container."
+                )
+            token = mint_adc_token()
+            return token, {
+                "x-portkey-vertex-project-id": self.gcp_project,
+                "x-portkey-vertex-region": self.gcp_region,
+            }
+        api_key = get_api_key(provider)
+        if not api_key:
+            raise RuntimeError(f"missing API key for provider {provider}")
+        return api_key, {}
+
+    def on_response_headers(
+        self,
+        headers: service_pb2.HttpHeaders,
+        context: ServicerContext,
+    ) -> service_pb2.HeadersResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return None
+        resp = service_pb2.HeadersResponse()
+        # Provider's Content-Length will be wrong after our body transform.
+        # Drop it so Envoy switches to chunked transfer encoding. Drop
+        # Content-Encoding too: providers may gzip despite our
+        # Accept-Encoding: identity, and the body we return is plain JSON,
+        # so a stale gzip header would break decoding clients.
+        resp.response.header_mutation.remove_headers.append("content-length")
+        resp.response.header_mutation.remove_headers.append("content-encoding")
+        return resp
+
+    def on_response_body(
+        self,
+        body: service_pb2.HttpBody,
+        context: ServicerContext,
+    ) -> service_pb2.BodyResponse | service_pb2.ImmediateResponse | None:
+        state = _state(context)
+        if not state.is_llm:
+            return None
+        if not body.end_of_stream:
+            # The LB delivers response bodies STREAMED: providers that flush
+            # in several pieces (for example OpenRouter's keep-alive padding)
+            # arrive as multiple chunks. Buffer each chunk and clear it from
+            # the egress; the full body is translated on the final chunk.
+            state.response_chunks.append(body.body or b"")
+            resp = service_pb2.BodyResponse()
+            resp.response.body_mutation.clear_body = True
+            return resp
+
+        if state.provider is None:
+            logging.error(
+                "on_response_body called without provider set (corr=%s)",
+                state.correlation,
+            )
+            return callout_tools.header_immediate_response(
+                StatusCode.InternalServerError)
+
+        provider_response = b"".join(state.response_chunks) + (body.body or b"")
+        # Some providers (notably Vertex AI) gzip responses even when we ask
+        # for ``identity`` via Accept-Encoding. Detect by magic bytes and
+        # decompress so Portkey's response transformer sees plain JSON.
+        if provider_response[:3] == b"\x1f\x8b\x08":
+            try:
+                provider_response = gzip.decompress(provider_response)
+                logging.info(
+                    "decompressed gzipped %s response (corr=%s)",
+                    state.provider, state.correlation)
+            except Exception:
+                logging.exception(
+                    "gzip-magic detected but decompress failed (corr=%s)",
+                    state.correlation)
+        spec = PROVIDERS[state.provider]
+
+        # On any failure below the body passes through untranslated. Earlier
+        # chunks were cleared from the egress, so the pass-through response
+        # must carry the full reassembled body, not just the final chunk.
+        def passthrough() -> service_pb2.BodyResponse:
+            resp = service_pb2.BodyResponse()
+            resp.response.body_mutation.body = provider_response
+            return resp
+
+        try:
+            api_key, extra_headers = self._auth_for(state.provider)
+        except Exception:
+            logging.exception("auth setup failed on response phase")
+            # Pass body through on auth failure. We can't safely synthesize
+            # an ImmediateResponse here without crashing the framework's
+            # response_body wrapper.
+            return passthrough()
+
+        if self._capture is None or self._client is None:
+            raise RuntimeError("async components not initialized")
+
+        self._capture.arm_response(state.correlation, provider_response)
+        custom_host = f"http://127.0.0.1:{self._capture.response_port}"
+        try:
+            portkey_resp = self._run_async(self._client.translate(
+                openai_body=state.request_body,
+                provider=spec.portkey_id,
+                api_key=api_key,
+                custom_host=custom_host,
+                correlation=state.correlation,
+                extra_headers=extra_headers,
+            ))
+        except Exception:
+            logging.exception("Portkey response-translation call failed; "
+                              "passing provider body through unchanged")
+            self._capture.disarm(state.correlation)
+            return passthrough()
+
+        if portkey_resp.status_code != 200:
+            logging.error(
+                "Portkey response translation status %s; passing provider "
+                "body through unchanged. Portkey error body: %s",
+                portkey_resp.status_code, portkey_resp.text[:500])
+            self._capture.disarm(state.correlation)
+            return passthrough()
+
+        new_body = portkey_resp.content
+        body_resp = service_pb2.BodyResponse()
+        body_resp.response.body_mutation.body = new_body
+        body_resp.response.header_mutation.set_headers.append(
+            HeaderValueOption(
+                header=HeaderValue(
+                    key="content-length",
+                    raw_value=str(len(new_body)).encode("utf-8"),
+                ),
+                append_action=HeaderValueOption.OVERWRITE_IF_EXISTS_OR_ADD,
+            ))
+        return body_resp
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    PortkeyGatewayCallout(disable_tls=True).run()

--- a/callouts/python/extproc/example/portkey_gateway/service_callout_example.py
+++ b/callouts/python/extproc/example/portkey_gateway/service_callout_example.py
@@ -18,14 +18,20 @@
 * Sends it to the Portkey sidecar (``localhost:8787``) with
   ``x-portkey-custom-host: http://localhost:9999`` and the provider API key.
 * Portkey translates OpenAI -> provider format and POSTs to ``:9999``, where
-  the callout's capture server records the translated bytes/headers/path.
+  the callout's capture server records the translated bytes/headers/path and
+  then *parks* the connection without answering.
 * The callout returns the captured provider-native bytes to the LB as ext_proc
   mutations; the LB forwards to the provider Internet NEG selected by the URL
   map's ``header_matches: x-model-id`` (prefix match on the provider segment).
-* On the response, the LB delivers the provider-native response back; the
-  callout arms ``:9998`` with those bytes, calls Portkey again with
-  ``x-portkey-custom-host: http://localhost:9998``, and returns Portkey's
-  OpenAI-shaped translation to the LB.
+* On the response, the LB delivers the provider-native response back. The
+  callout hands those bytes to the capture server, which writes them on the
+  parked connection. Portkey translates them and the original call resolves
+  with the OpenAI-shaped response.
+
+A single Portkey call therefore spans both ext_proc phases. Portkey sees one
+ordinary request/response exchange on one connection, so the callout makes no
+assumptions about whether Portkey keeps state between a request and its
+response, and no stub response bodies are needed.
 
 Routing model: the LB's URL map picks the provider backend from the
 ``x-model-id`` header *before* this callout fires.
@@ -51,6 +57,7 @@ import logging
 import os
 import threading
 import uuid
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
@@ -226,6 +233,17 @@ _BROWSER_HEADERS = (
 )
 
 
+# How long to wait for Portkey to POST the translated request to the capture
+# server. This is a localhost round-trip through Portkey's transformer, so it
+# is fast; a miss means the sidecar is unhealthy.
+_CAPTURE_TIMEOUT = 30.0
+
+# How long to wait for the parked Portkey call to resolve once the provider's
+# response has been supplied. Only the final translation remains at that
+# point, so this is also a localhost operation.
+_TRANSLATE_TIMEOUT = 30.0
+
+
 @dataclass
 class _StreamState:
     is_llm: bool = False
@@ -234,6 +252,9 @@ class _StreamState:
     request_body: dict[str, Any] = field(default_factory=dict)
     # Response-body chunks accumulated across STREAMED ext_proc messages.
     response_chunks: list[bytes] = field(default_factory=list)
+    # The in-flight Portkey call, started in the request phase and resolved in
+    # the response phase once the parked connection is answered.
+    portkey_call: Future | None = None
 
 
 def _state(context: ServicerContext) -> _StreamState:
@@ -254,10 +275,7 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
         self.portkey_url = os.getenv(
             "PORTKEY_BASE_URL", "http://127.0.0.1:8787")
 
-        self._capture_request_port = int(
-            os.getenv("CAPTURE_REQUEST_PORT", "9999"))
-        self._capture_response_port = int(
-            os.getenv("CAPTURE_RESPONSE_PORT", "9998"))
+        self._capture_port = int(os.getenv("CAPTURE_PORT", "9999"))
 
         # The capture server and Portkey client are spun up lazily on a worker
         # thread because the gRPC server runs on its own thread pool and we
@@ -277,9 +295,7 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
             asyncio.set_event_loop(loop)
             self._loop = loop
             self._capture = capture_server.CaptureServer(
-                request_port=self._capture_request_port,
-                response_port=self._capture_response_port,
-            )
+                port=self._capture_port)
             self._client = portkey_client.PortkeyClient(
                 base_url=self.portkey_url)
             loop.run_until_complete(self._capture.start())
@@ -298,13 +314,30 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
         if self._capture is None or self._client is None:
             raise RuntimeError("async components missing after loop start")
 
-    def _run_async(self, coro):
+    def _run_async(self, coro, timeout: float = 30.0):
         # self._loop is guaranteed non-None once __init__ returns.
         future = asyncio.run_coroutine_threadsafe(
             coro, self._loop)  # type: ignore[arg-type]
         # Timeout so a hung sidecar surfaces as concurrent.futures.TimeoutError
         # rather than hanging the gRPC thread indefinitely.
-        return future.result(timeout=30)
+        return future.result(timeout=timeout)
+
+    def _abandon_portkey_call(self, state: _StreamState) -> None:
+        """Release capture state and drop the in-flight Portkey call.
+
+        Unparking first lets the parked handler return immediately instead of
+        waiting out the full park timeout; the Portkey coroutine then finishes
+        on its own, so the cancel is only a backstop.
+        """
+        if self._capture is not None:
+            try:
+                self._run_async(self._capture.disarm(state.correlation))
+            except Exception:
+                logging.exception("failed to disarm capture state (corr=%s)",
+                                  state.correlation)
+        if state.portkey_call is not None:
+            state.portkey_call.cancel()
+            state.portkey_call = None
 
     # ---------------- ext_proc phases ----------------
 
@@ -396,31 +429,61 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
 
         if self._capture is None or self._client is None:
             raise RuntimeError("async components not initialized")
-        self._capture.arm_request(state.correlation, provider)
-        custom_host = f"http://127.0.0.1:{self._capture.request_port}"
-        try:
-            self._run_async(self._client.translate(
+        self._run_async(self._capture.arm(state.correlation))
+        custom_host = f"http://127.0.0.1:{self._capture.port}"
+        # Start the Portkey call without waiting for it to finish. It blocks
+        # inside the capture server on the parked connection until the
+        # response phase supplies the provider's answer.
+        state.portkey_call = asyncio.run_coroutine_threadsafe(
+            self._client.translate(
                 openai_body=state.request_body,
                 provider=spec.portkey_id,
                 api_key=api_key,
                 custom_host=custom_host,
                 correlation=state.correlation,
                 extra_headers=extra_headers,
-            ))
-        except Exception:
-            logging.exception("Portkey request-translation call failed")
-            self._capture.disarm(state.correlation)
-            return callout_tools.header_immediate_response(
-                StatusCode.BadGateway)
+            ),
+            self._loop,  # type: ignore[arg-type]
+        )
+        # If the call completes before Portkey POSTed anything (it raised, or
+        # Portkey answered with its own error response), no capture is coming:
+        # wake the waiter immediately rather than letting it sit out the
+        # capture timeout. In the normal flow the call resolves long after
+        # capture, where this wake is a harmless no-op.
+        correlation = state.correlation
+
+        def _wake_when_done(fut: Future) -> None:
+            if not fut.cancelled():
+                asyncio.run_coroutine_threadsafe(
+                    self._capture.fail(correlation),  # type: ignore[union-attr]
+                    self._loop)  # type: ignore[arg-type]
+
+        state.portkey_call.add_done_callback(_wake_when_done)
 
         try:
-            captured = self._capture.take_captured_request(state.correlation)
-        except KeyError:
-            logging.error(
-                "Portkey did not POST to capture server (corr=%s)",
-                state.correlation,
-            )
-            self._capture.disarm(state.correlation)
+            captured = self._run_async(
+                self._capture.wait_for_capture(
+                    state.correlation, _CAPTURE_TIMEOUT),
+                timeout=_CAPTURE_TIMEOUT + 5)
+        except Exception:
+            # Surface the real cause: the Portkey call's own failure or error
+            # response if it finished, otherwise the capture timeout.
+            call = state.portkey_call
+            if call.done() and not call.cancelled() and call.exception():
+                logging.error(
+                    "Portkey request-translation call failed (corr=%s): %s",
+                    state.correlation, call.exception())
+            elif call.done() and not call.cancelled():
+                portkey_resp = call.result()
+                logging.error(
+                    "Portkey answered %s without calling the capture server "
+                    "(corr=%s): %s", portkey_resp.status_code,
+                    state.correlation, portkey_resp.text[:500])
+            else:
+                logging.exception(
+                    "Portkey did not POST to capture server (corr=%s)",
+                    state.correlation)
+            self._abandon_portkey_call(state)
             return callout_tools.header_immediate_response(
                 StatusCode.BadGateway)
 
@@ -533,8 +596,6 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
                 logging.exception(
                     "gzip-magic detected but decompress failed (corr=%s)",
                     state.correlation)
-        spec = PROVIDERS[state.provider]
-
         # On any failure below the body passes through untranslated. Earlier
         # chunks were cleared from the egress, so the pass-through response
         # must carry the full reassembled body, not just the final chunk.
@@ -543,33 +604,28 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
             resp.response.body_mutation.body = provider_response
             return resp
 
-        try:
-            api_key, extra_headers = self._auth_for(state.provider)
-        except Exception:
-            logging.exception("auth setup failed on response phase")
-            # Pass body through on auth failure. We can't safely synthesize
-            # an ImmediateResponse here without crashing the framework's
-            # response_body wrapper.
-            return passthrough()
-
         if self._capture is None or self._client is None:
             raise RuntimeError("async components not initialized")
 
-        self._capture.arm_response(state.correlation, provider_response)
-        custom_host = f"http://127.0.0.1:{self._capture.response_port}"
+        if state.portkey_call is None:
+            logging.error(
+                "no in-flight Portkey call for this response (corr=%s)",
+                state.correlation)
+            return passthrough()
+
+        # Unpark the connection Portkey has held since the request phase by
+        # writing the provider's response onto it. No second Portkey call and
+        # no auth are needed here: the original call is still open and
+        # resolves with the translated response.
+        self._run_async(self._capture.provide_response(
+            state.correlation, provider_response))
         try:
-            portkey_resp = self._run_async(self._client.translate(
-                openai_body=state.request_body,
-                provider=spec.portkey_id,
-                api_key=api_key,
-                custom_host=custom_host,
-                correlation=state.correlation,
-                extra_headers=extra_headers,
-            ))
+            portkey_resp = state.portkey_call.result(
+                timeout=_TRANSLATE_TIMEOUT)
         except Exception:
-            logging.exception("Portkey response-translation call failed; "
+            logging.exception("Portkey response translation failed; "
                               "passing provider body through unchanged")
-            self._capture.disarm(state.correlation)
+            self._abandon_portkey_call(state)
             return passthrough()
 
         if portkey_resp.status_code != 200:
@@ -577,7 +633,6 @@ class PortkeyGatewayCallout(callout_server.CalloutServer):
                 "Portkey response translation status %s; passing provider "
                 "body through unchanged. Portkey error body: %s",
                 portkey_resp.status_code, portkey_resp.text[:500])
-            self._capture.disarm(state.correlation)
             return passthrough()
 
         new_body = portkey_resp.content

--- a/callouts/python/extproc/tests/portkey_gateway_test.py
+++ b/callouts/python/extproc/tests/portkey_gateway_test.py
@@ -1,0 +1,896 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Portkey Gateway Python callout.
+
+Pure unit tests: no gRPC server started, no Portkey sidecar started, no
+network calls. Phase methods and helpers are called directly with synthetic
+proto objects or simple inputs; HTTP interactions with the Portkey sidecar
+are mocked via ``respx``.
+"""
+
+import gzip
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from aiohttp import ClientSession
+
+from envoy.config.core.v3.base_pb2 import HeaderMap, HeaderValue
+from envoy.extensions.filters.http.ext_proc.v3.processing_mode_pb2 import (
+    ProcessingMode,
+)
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.type.v3.http_status_pb2 import StatusCode
+
+from extproc.example.portkey_gateway import service_callout_example as sce
+from extproc.example.portkey_gateway.capture_server import (
+    REQUEST_CAPTURE_PROVIDERS,
+    build_stub_response,
+    CaptureServer,
+)
+from extproc.example.portkey_gateway.portkey_client import PortkeyClient
+from extproc.example.portkey_gateway.service_callout_example import (
+    HEADER_PORTKEY_ROUTED,
+    HEADER_PORTKEY_PROVIDER,
+    PortkeyGatewayCallout,
+    PROVIDERS,
+    detect_provider_from_model,
+    get_api_key,
+    _state,
+)
+
+pytest_plugins = ["pytest_asyncio"]
+
+
+def test_detect_provider_from_model_splits_first_segment():
+    assert detect_provider_from_model(
+        "anthropic/claude-3-5-sonnet-20241022") == (
+        "anthropic", "claude-3-5-sonnet-20241022")
+    assert detect_provider_from_model("groq/compound-beta") == (
+        "groq", "compound-beta")
+    assert detect_provider_from_model("openrouter/openai/gpt-oss-20b:free") == (
+        "openrouter", "openai/gpt-oss-20b:free")
+
+
+def test_detect_provider_defaults_to_vertex_ai_when_no_prefix():
+    assert detect_provider_from_model("gemini-2.5-flash") == (
+        "vertex_ai", "gemini-2.5-flash")
+
+
+def test_providers_registry_has_four_supported_providers():
+    assert set(PROVIDERS) == {"anthropic", "vertex_ai", "groq", "openrouter"}
+
+
+def test_get_api_key_reads_env_var():
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-xxx"}):
+        assert get_api_key("anthropic") == "sk-ant-xxx"
+
+
+def test_get_api_key_returns_none_for_vertex():
+    assert get_api_key("vertex_ai") is None
+
+
+def test_get_api_key_returns_none_for_unknown_provider():
+    assert get_api_key("does-not-exist") is None
+
+
+def test_mint_adc_token_returns_credentials_token():
+    fake_creds = MagicMock()
+    fake_creds.token = "ya29.fake-adc-token"
+    fake_creds.valid = True
+    with patch.object(sce, "_load_default_credentials",
+                      return_value=fake_creds):
+        assert sce.mint_adc_token() == "ya29.fake-adc-token"
+
+
+def test_mint_adc_token_refreshes_when_invalid():
+    fake_creds = MagicMock()
+    fake_creds.valid = False
+    fake_creds.token = "ya29.refreshed"
+
+    def _refresh(_req):
+        fake_creds.valid = True
+
+    fake_creds.refresh.side_effect = _refresh
+    with patch.object(sce, "_load_default_credentials",
+                      return_value=fake_creds):
+        assert sce.mint_adc_token() == "ya29.refreshed"
+        assert fake_creds.refresh.called
+
+
+def test_build_stub_response_anthropic_minimum_fields():
+    body = build_stub_response("anthropic")
+    parsed = json.loads(body)
+    # Anthropic response shape: id/type/role/content/model/usage.
+    assert parsed["type"] == "message"
+    assert parsed["role"] == "assistant"
+    assert isinstance(parsed["content"], list)
+    assert parsed["content"] and parsed["content"][0]["type"] == "text"
+    assert "usage" in parsed
+
+
+def test_build_stub_response_vertex_minimum_fields():
+    body = build_stub_response("vertex_ai")
+    parsed = json.loads(body)
+    # Vertex generateContent shape.
+    assert "candidates" in parsed and parsed["candidates"]
+    assert parsed["candidates"][0]["content"]["role"] == "model"
+
+
+def test_build_stub_response_groq_returns_openai_chat_shape():
+    body = build_stub_response("groq")
+    parsed = json.loads(body)
+    assert parsed["object"] == "chat.completion"
+    assert parsed["choices"][0]["message"]["role"] == "assistant"
+
+
+def test_build_stub_response_openrouter_returns_openai_chat_shape():
+    body = build_stub_response("openrouter")
+    parsed = json.loads(body)
+    assert parsed["object"] == "chat.completion"
+    assert parsed["choices"][0]["message"]["role"] == "assistant"
+
+
+def test_request_capture_providers_match_callout_registry():
+    # Every provider the callout can route must have a stub response shape,
+    # or the request-capture loopback breaks when that provider is used.
+    assert set(REQUEST_CAPTURE_PROVIDERS) == set(PROVIDERS)
+
+
+def test_disarm_clears_pending_correlation_state():
+    server = CaptureServer(request_port=0, response_port=0)
+    server.arm_request("corr-1", provider="anthropic")
+    server.arm_response("corr-1", b"provider bytes")
+    server.disarm("corr-1")
+    assert server._armed_request == {}
+    assert server._armed_response == {}
+    # Disarming an unknown correlation is a no-op, not an error.
+    server.disarm("corr-never-armed")
+
+
+@pytest.mark.asyncio
+async def test_request_capture_stores_body_and_returns_stub():
+    server = CaptureServer(request_port=0, response_port=0)
+    await server.start()
+    try:
+        # Pre-arm: tell the server which provider this correlation id targets.
+        server.arm_request("corr-1", provider="anthropic")
+
+        url = f"http://127.0.0.1:{server.request_port}/v1/messages"
+        async with ClientSession() as s:
+            r = await s.post(
+                url,
+                data=b'{"model":"claude-3","messages":[]}',
+                headers={
+                    "x-api-key": "sk-ant-xxx",
+                    "anthropic-version": "2023-06-01",
+                    "x-portkey-callout-correlation": "corr-1",
+                },
+            )
+            stub_body = await r.read()
+
+        captured = server.take_captured_request("corr-1")
+        assert captured.body == b'{"model":"claude-3","messages":[]}'
+        assert captured.path == "/v1/messages"
+        assert captured.headers["x-api-key"] == "sk-ant-xxx"
+        # Stub response is Anthropic-shaped.
+        assert b'"type": "message"' in stub_body
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_response_replay_returns_armed_bytes():
+    server = CaptureServer(request_port=0, response_port=0)
+    await server.start()
+    armed = b'{"id":"msg_real","content":[{"type":"text","text":"hello"}]}'
+    try:
+        server.arm_response("corr-2", armed)
+        async with ClientSession() as s:
+            r = await s.post(
+                f"http://127.0.0.1:{server.response_port}/v1/messages",
+                data=b'{"model":"claude-3","messages":[]}',
+                headers={"x-portkey-callout-correlation": "corr-2"},
+            )
+            body = await r.read()
+        assert body == armed
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_capture_rejects_missing_correlation_header():
+    server = CaptureServer(request_port=0, response_port=0)
+    await server.start()
+    try:
+        async with ClientSession() as s:
+            r = await s.post(
+                f"http://127.0.0.1:{server.request_port}/anything",
+                data=b"",
+            )
+            assert r.status == 400
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_translate_calls_portkey_with_expected_headers():
+    route = respx.post("http://127.0.0.1:8787/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200, json={"id": "stub", "object": "chat.completion"}))
+    client = PortkeyClient(base_url="http://127.0.0.1:8787")
+    try:
+        await client.translate(
+            openai_body={"model": "claude-3-5-sonnet", "messages": []},
+            provider="anthropic",
+            api_key="sk-ant-xxx",
+            custom_host="http://127.0.0.1:9999",
+            correlation="corr-3",
+            extra_headers={},
+        )
+    finally:
+        await client.close()
+
+    assert route.called
+    req = route.calls.last.request
+    assert req.headers["x-portkey-provider"] == "anthropic"
+    assert req.headers["x-portkey-custom-host"] == "http://127.0.0.1:9999"
+    assert req.headers["authorization"] == "Bearer sk-ant-xxx"
+    assert req.headers["x-portkey-callout-correlation"] == "corr-3"
+    # Correlation must be in the forwarded-headers list so Portkey passes
+    # it on.
+    forward = req.headers["x-portkey-forward-headers"]
+    assert "x-portkey-callout-correlation" in forward
+    # stream=true would be added by client if requested; force-false otherwise.
+    body = json.loads(req.content)
+    assert body["stream"] is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_translate_includes_extra_headers_in_forward_list():
+    respx.post("http://127.0.0.1:8787/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json={}))
+    client = PortkeyClient(base_url="http://127.0.0.1:8787")
+    try:
+        await client.translate(
+            openai_body={"model": "x", "messages": []},
+            provider="vertex-ai",
+            api_key="ya29.fake",
+            custom_host="http://127.0.0.1:9999",
+            correlation="corr-vx",
+            extra_headers={
+                "x-portkey-vertex-project-id": "test-project",
+                "x-portkey-vertex-region": "us-central1",
+            },
+        )
+    finally:
+        await client.close()
+
+    req = respx.calls.last.request
+    forward_list = req.headers["x-portkey-forward-headers"]
+    assert "x-portkey-callout-correlation" in forward_list
+    assert "x-portkey-vertex-project-id" in forward_list
+    assert "x-portkey-vertex-region" in forward_list
+    # Vertex headers themselves are also set on the outbound request.
+    assert req.headers["x-portkey-vertex-project-id"] == "test-project"
+    assert req.headers["x-portkey-vertex-region"] == "us-central1"
+
+
+@pytest.fixture(scope="module")
+def svc():
+    """Callout instance: no gRPC server, no GCP creds, no Portkey sidecar."""
+    with patch.dict(os.environ, {
+        "GCP_PROJECT_ID": "test-project",
+        "GCP_REGION": "us-central1",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+        "GROQ_API_KEY": "gsk-test",
+        "OPENROUTER_API_KEY": "or-test",
+        # Point at a port nothing is listening on; respx mocks the actual call.
+        "PORTKEY_BASE_URL": "http://127.0.0.1:1",
+        # Use OS-picked ephemeral ports so test runs never collide with each
+        # other or with a real capture server.
+        "CAPTURE_REQUEST_PORT": "0",
+        "CAPTURE_RESPONSE_PORT": "0",
+    }):
+        callout = PortkeyGatewayCallout(
+            disable_tls=True,
+            combined_health_check=True,
+        )
+        yield callout
+
+
+def _http_headers(d: dict) -> service_pb2.HttpHeaders:
+    hm = HeaderMap()
+    for k, v in d.items():
+        hm.headers.append(HeaderValue(key=k, raw_value=v.encode()))
+    return service_pb2.HttpHeaders(headers=hm)
+
+
+class _Ctx:
+    """Minimal ServicerContext substitute: supports attribute assignment."""
+
+
+def test_non_llm_path_is_passthrough(svc):
+    ctx = _Ctx()
+    resp = svc.on_request_headers(
+        _http_headers({":path": "/", ":method": "GET"}), ctx)
+    assert resp is None
+    state = _state(ctx)
+    assert state.is_llm is False
+
+
+def test_llm_path_marks_state_and_stamps_routed_header(svc):
+    ctx = _Ctx()
+    resp = svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions", ":method": "POST"}),
+        ctx,
+    )
+    assert resp is not None
+    state = _state(ctx)
+    assert state.is_llm is True
+    assert state.correlation != ""  # uuid4 hex, ~32 chars
+    headers = {
+        hvo.header.key: hvo.header.raw_value.decode()
+        for hvo in resp.request_headers.response.header_mutation.set_headers
+    }
+    assert headers[HEADER_PORTKEY_ROUTED] == "true"
+    # BUFFERED body delivery is required: providers that flush response
+    # bodies in several chunks (e.g. OpenRouter) break translation otherwise.
+    assert resp.mode_override.request_body_mode == ProcessingMode.BUFFERED
+    assert resp.mode_override.response_body_mode == ProcessingMode.BUFFERED
+    # Browser-identifying headers must be stripped: Anthropic 401s requests
+    # that carry an Origin header (direct-browser-access guard).
+    removed = list(
+        resp.request_headers.response.header_mutation.remove_headers)
+    for h in ("origin", "referer", "cookie", "sec-fetch-mode"):
+        assert h in removed
+
+
+def test_response_headers_drops_content_length(svc):
+    ctx = _Ctx()
+    # Pretend we already saw a request-headers event for an LLM path.
+    state = _state(ctx)
+    state.is_llm = True
+    resp = svc.on_response_headers(
+        _http_headers({"content-length": "1234"}), ctx)
+    removed = list(resp.response.header_mutation.remove_headers)
+    assert "content-length" in removed
+    # Stale gzip header must not survive the body transform.
+    assert "content-encoding" in removed
+
+
+@pytest.mark.asyncio
+async def test_on_request_body_anthropic_drives_capture_and_rewrites(svc):
+    """End-to-end: callout drives Portkey (mocked), capture records, callout
+    returns provider-native bytes + headers."""
+    async def fake_portkey(request: httpx.Request) -> httpx.Response:
+        corr = request.headers["x-portkey-callout-correlation"]
+        # Simulate Portkey: POST a translated Anthropic-format request to the
+        # callout's capture server using the same correlation id.
+        # Use an explicit real transport (bypassing respx) so the request
+        # actually reaches the capture server running on the worker event loop.
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport()) as c:
+            # Real Portkey strips the provider's URL prefix when forwarding to
+            # custom_host (Anthropic's `/v1/messages` becomes `/messages`).
+            # The callout's `api_path_prefix` reattaches `/v1` before the LB
+            # forwards to api.anthropic.com.
+            await c.post(
+                f"http://127.0.0.1:{svc._capture.request_port}/messages",
+                content=(b'{"model":"claude-3-5-sonnet","max_tokens":32,'
+                         b'"messages":[{"role":"user","content":"hi"}]}'),
+                headers={
+                    "x-api-key": "sk-ant-test",
+                    "anthropic-version": "2023-06-01",
+                    "x-portkey-callout-correlation": corr,
+                },
+            )
+        return httpx.Response(
+            200, json={"id": "stub", "object": "chat.completion"})
+
+    # Use the context-manager form so the route is registered on the local
+    # router that is actually started and visible to the worker-thread httpx
+    # calls.  The capture-server POST is registered as pass-through so
+    # fake_portkey's real HTTP request actually reaches the aiohttp server
+    # (rather than being auto-mocked to an empty 200 by respx).
+    with respx.mock(
+        assert_all_called=False, assert_all_mocked=False,
+    ) as mock_router:
+        mock_router.post("http://127.0.0.1:1/v1/chat/completions").mock(
+            side_effect=fake_portkey)
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.request_port).pass_through()
+
+        ctx = _Ctx()
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions"}), ctx)
+        body = service_pb2.HttpBody(body=json.dumps({
+            "model": "anthropic/claude-3-5-sonnet",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode())
+        resp = svc.on_request_body(body, ctx)
+
+    assert isinstance(resp, service_pb2.BodyResponse)
+    new_body = resp.response.body_mutation.body
+    parsed = json.loads(new_body)
+    assert parsed["model"] == "claude-3-5-sonnet"
+    assert parsed["messages"][0]["content"] == "hi"
+
+    set_headers = {
+        hvo.header.key: hvo.header.raw_value.decode()
+        for hvo in resp.response.header_mutation.set_headers
+    }
+    assert set_headers[":authority"] == "api.anthropic.com"
+    assert set_headers[":path"] == "/v1/messages"
+    assert set_headers["x-api-key"] == "sk-ant-test"
+    assert set_headers["anthropic-version"] == "2023-06-01"
+    assert set_headers[HEADER_PORTKEY_PROVIDER] == "anthropic"
+    # Internal correlation header must NOT leak to the provider.
+    assert "x-portkey-callout-correlation" not in set_headers
+
+
+def test_on_request_body_empty_body_is_passthrough(svc):
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    resp = svc.on_request_body(service_pb2.HttpBody(body=b""), ctx)
+    # Unexpected but tolerated: logged as a warning and passed through.
+    assert isinstance(resp, service_pb2.BodyResponse)
+    assert resp.response.body_mutation.body == b""
+
+
+def test_on_request_body_portkey_failure_disarms_capture(svc, monkeypatch):
+    async def boom(**kwargs):
+        raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(svc._client, "translate", boom)
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "anthropic/claude-3-5-sonnet",
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode())
+    resp = svc.on_request_body(body, ctx)
+    assert resp.status.code == StatusCode.BadGateway
+    # The failed correlation must not linger in the capture server.
+    corr = _state(ctx).correlation
+    assert corr not in svc._capture._armed_request
+    assert corr not in svc._capture._captured
+
+
+def test_on_request_body_anthropic_defaults_max_tokens(svc, monkeypatch):
+    """Anthropic's Messages API requires max_tokens; OpenAI clients usually
+    omit it. The callout must fill in the spec default, but never override
+    a client-provided value."""
+    captured = {}
+
+    async def fake_translate(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop after capture")
+
+    monkeypatch.setattr(svc._client, "translate", fake_translate)
+
+    # Client omits max_tokens: the spec default is injected.
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "anthropic/claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode())
+    svc.on_request_body(body, ctx)
+    assert captured["openai_body"]["max_tokens"] == 4096
+
+    # Client sets max_tokens: passed through untouched.
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "anthropic/claude-haiku-4-5",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode())
+    svc.on_request_body(body, ctx)
+    assert captured["openai_body"]["max_tokens"] == 32
+
+
+def test_on_request_body_invalid_json_returns_400(svc):
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    resp = svc.on_request_body(service_pb2.HttpBody(body=b"not json"), ctx)
+    # on_request_body returns ImmediateResponse directly; the gRPC server wraps
+    # it in ProcessingResponse(immediate_response=...) at dispatch time.
+    assert resp.status.code == StatusCode.BadRequest
+
+
+def test_on_request_body_missing_model_returns_400(svc):
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({"messages": []}).encode())
+    resp = svc.on_request_body(body, ctx)
+    assert resp.status.code == StatusCode.BadRequest
+
+
+def test_on_request_body_unknown_provider_returns_400(svc):
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "mistral/mistral-large", "messages": [],
+    }).encode())
+    resp = svc.on_request_body(body, ctx)
+    assert resp.status.code == StatusCode.BadRequest
+
+
+@pytest.mark.asyncio
+async def test_on_response_body_translates_anthropic_to_openai(svc):
+    """Response phase: callout has captured request state, gets Anthropic-format
+    response from LB, replays through Portkey, returns OpenAI body."""
+    with respx.mock(
+        base_url="http://127.0.0.1:1",
+        assert_all_mocked=False,
+        assert_all_called=False,
+    ) as mock_router:
+        # Let the inner httpx.AsyncClient hit the real localhost capture server.
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.response_port
+        ).pass_through()
+
+        replay_port = svc._capture.response_port
+
+        async def fake_portkey(request: httpx.Request) -> httpx.Response:
+            corr = request.headers["x-portkey-callout-correlation"]
+            # Simulate Portkey: POST to :9998 and let it stream the captured
+            # provider response back; here we just verify the replay happens.
+            async with httpx.AsyncClient() as c:
+                r = await c.post(
+                    f"http://127.0.0.1:{replay_port}/v1/messages",
+                    content=b"",
+                    headers={"x-portkey-callout-correlation": corr},
+                )
+                provider_body = await r.aread()
+            # In reality Portkey parses provider_body and emits OpenAI; we
+            # synthesize one for the test.
+            assert b'"msg_real"' in provider_body
+            return httpx.Response(200, json={
+                "id": "chatcmpl-fake",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi back"},
+                    "finish_reason": "stop",
+                }],
+            })
+
+        mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
+
+        # Arrange callout state as if the request phase had run successfully.
+        ctx = _Ctx()
+        state = _state(ctx)
+        state.is_llm = True
+        state.provider = "anthropic"
+        state.correlation = "corr-rsp-1"
+        state.request_body = {"model": "claude-3-5-sonnet", "messages": []}
+
+        anthropic_response = (
+            b'{"id":"msg_real","type":"message",'
+            b'"content":[{"type":"text","text":"hi back"}],'
+            b'"usage":{"input_tokens":1,"output_tokens":2}}'
+        )
+        body = service_pb2.HttpBody(body=anthropic_response, end_of_stream=True)
+        resp = svc.on_response_body(body, ctx)
+
+        assert isinstance(resp, service_pb2.BodyResponse)
+        new_body = json.loads(resp.response.body_mutation.body)
+        assert new_body["object"] == "chat.completion"
+        assert new_body["choices"][0]["message"]["content"] == "hi back"
+
+
+@pytest.mark.asyncio
+async def test_on_response_body_reassembles_chunked_gzip_response(svc):
+    """Replicates the production OpenRouter behavior: a gzipped provider
+    response delivered as several STREAMED chunks. The callout must buffer
+    the chunks, gunzip the reassembled body, and translate it."""
+    with respx.mock(
+        base_url="http://127.0.0.1:1",
+        assert_all_mocked=False,
+        assert_all_called=False,
+    ) as mock_router:
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.response_port
+        ).pass_through()
+
+        replay_port = svc._capture.response_port
+
+        async def fake_portkey(request: httpx.Request) -> httpx.Response:
+            corr = request.headers["x-portkey-callout-correlation"]
+            async with httpx.AsyncClient() as c:
+                r = await c.post(
+                    f"http://127.0.0.1:{replay_port}/v1/chat/completions",
+                    content=b"",
+                    headers={"x-portkey-callout-correlation": corr},
+                )
+                provider_body = await r.aread()
+            # The replayed body must be the gunzipped, reassembled JSON.
+            replayed = json.loads(provider_body)
+            assert replayed["id"] == "gen-or-1"
+            return httpx.Response(200, json={
+                "id": "chatcmpl-or",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi back"},
+                    "finish_reason": "stop",
+                }],
+            })
+
+        mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
+
+        ctx = _Ctx()
+        state = _state(ctx)
+        state.is_llm = True
+        state.provider = "openrouter"
+        state.correlation = "corr-or-1"
+        state.request_body = {"model": "openai/gpt-oss-20b:free",
+                              "messages": []}
+
+        compressed = gzip.compress(
+            b'{"id":"gen-or-1","object":"chat.completion","choices":[]}')
+        # Split mid-stream so neither later fragment carries the gzip magic.
+        first, second, last = (
+            compressed[:5], compressed[5:11], compressed[11:])
+        for fragment in (first, second):
+            r = svc.on_response_body(
+                service_pb2.HttpBody(body=fragment, end_of_stream=False), ctx)
+            assert r.response.body_mutation.clear_body is True
+        resp = svc.on_response_body(
+            service_pb2.HttpBody(body=last, end_of_stream=True), ctx)
+
+        assert isinstance(resp, service_pb2.BodyResponse)
+        new_body = json.loads(resp.response.body_mutation.body)
+        assert new_body["id"] == "chatcmpl-or"
+        assert new_body["choices"][0]["message"]["content"] == "hi back"
+
+
+def test_on_response_body_returns_none_for_non_llm(svc):
+    ctx = _Ctx()
+    # Don't set state.is_llm; default state.is_llm is False.
+    body = service_pb2.HttpBody(body=b"anything", end_of_stream=True)
+    assert svc.on_response_body(body, ctx) is None
+
+
+def test_on_response_body_buffers_mid_stream_chunks(svc):
+    ctx = _Ctx()
+    state = _state(ctx)
+    state.is_llm = True
+    # A mid-stream chunk (end_of_stream=False) is buffered in state and
+    # cleared from the egress; translation waits for the final chunk.
+    body = service_pb2.HttpBody(body=b"partial", end_of_stream=False)
+    resp = svc.on_response_body(body, ctx)
+    assert isinstance(resp, service_pb2.BodyResponse)
+    assert resp.response.body_mutation.clear_body is True
+    assert state.response_chunks == [b"partial"]
+
+
+def test_on_response_body_missing_provider_returns_500(svc):
+    ctx = _Ctx()
+    state = _state(ctx)
+    state.is_llm = True
+    # state.provider stays None (never set by a normal flow).
+    body = service_pb2.HttpBody(body=b"{}", end_of_stream=True)
+    resp = svc.on_response_body(body, ctx)
+    assert resp.status.code == StatusCode.InternalServerError
+
+
+def test_on_request_body_rejects_streaming_for_now(svc):
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "anthropic/claude-3-5-sonnet",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode())
+    resp = svc.on_request_body(body, ctx)
+    assert resp.status.code == StatusCode.NotImplemented
+
+
+@pytest.mark.asyncio
+async def test_on_request_body_vertex_uses_adc_token_and_region(svc):
+    with respx.mock(
+        base_url="http://127.0.0.1:1",
+        assert_all_mocked=False,
+        assert_all_called=False,
+    ) as mock_router:
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.request_port
+        ).pass_through()
+
+        capture_port = svc._capture.request_port
+        # Vertex AI is the no-prefix provider: Portkey emits the full
+        # generateContent path, so the callout forwards it verbatim.
+        vertex_path = (
+            "/v1/projects/test-project/locations/us-central1"
+            "/publishers/google/models/gemini-2.5-flash:generateContent"
+        )
+        vertex_body = b'{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
+
+        async def fake_portkey(request: httpx.Request) -> httpx.Response:
+            corr = request.headers["x-portkey-callout-correlation"]
+            # Verify Portkey received the Vertex project/region headers + ADC.
+            assert request.headers[
+                "x-portkey-vertex-project-id"] == "test-project"
+            assert request.headers["x-portkey-vertex-region"] == "us-central1"
+            assert request.headers["authorization"] == "Bearer ya29.fake"
+            async with httpx.AsyncClient() as c:
+                # Simulate Portkey POSTing a Vertex generateContent request to
+                # the capture server.
+                await c.post(
+                    f"http://127.0.0.1:{capture_port}{vertex_path}",
+                    content=vertex_body,
+                    headers={
+                        "authorization": "Bearer ya29.fake",
+                        "x-portkey-callout-correlation": corr,
+                    },
+                )
+            return httpx.Response(200, json={})
+
+        mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
+
+        with patch(
+            "extproc.example.portkey_gateway.service_callout_example"
+            ".mint_adc_token",
+            return_value="ya29.fake",
+        ):
+            ctx = _Ctx()
+            svc.on_request_headers(
+                _http_headers({":path": "/v1/chat/completions"}), ctx)
+            req = json.dumps({
+                "model": "vertex_ai/gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "hi"}],
+            }).encode()
+            resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+
+        assert isinstance(resp, service_pb2.BodyResponse)
+        set_headers = {
+            hvo.header.key: hvo.header.raw_value.decode()
+            for hvo in resp.response.header_mutation.set_headers
+        }
+        assert set_headers[":authority"] == (
+            "us-central1-aiplatform.googleapis.com")
+        # No api_path_prefix for Vertex: the captured path passes through.
+        assert set_headers[":path"] == vertex_path
+        assert set_headers["authorization"] == "Bearer ya29.fake"
+        # Provenance stamp uses Portkey's id ("vertex-ai"), not the
+        # client-facing "vertex_ai" prefix.
+        assert set_headers[HEADER_PORTKEY_PROVIDER] == "vertex-ai"
+
+
+@pytest.mark.asyncio
+async def test_on_request_body_groq_uses_api_key_env(svc):
+    with respx.mock(
+        base_url="http://127.0.0.1:1",
+        assert_all_mocked=False,
+        assert_all_called=False,
+    ) as mock_router:
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.request_port
+        ).pass_through()
+
+        capture_port = svc._capture.request_port
+
+        async def fake_portkey(request: httpx.Request) -> httpx.Response:
+            corr = request.headers["x-portkey-callout-correlation"]
+            assert request.headers["authorization"] == "Bearer gsk-test"
+            async with httpx.AsyncClient() as c:
+                # Real Portkey strips Groq's "/openai/v1" URL prefix when
+                # forwarding to custom_host; the callout reattaches it via
+                # api_path_prefix.
+                await c.post(
+                    f"http://127.0.0.1:{capture_port}/chat/completions",
+                    content=(b'{"model":"compound-beta","messages":'
+                             b'[{"role":"user","content":"hi"}]}'),
+                    headers={
+                        "authorization": "Bearer gsk-test",
+                        "x-portkey-callout-correlation": corr,
+                    },
+                )
+            return httpx.Response(200, json={})
+
+        mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
+
+        ctx = _Ctx()
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions"}), ctx)
+        req = json.dumps({
+            "model": "groq/compound-beta",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+
+        assert isinstance(resp, service_pb2.BodyResponse)
+        set_headers = {
+            hvo.header.key: hvo.header.raw_value.decode()
+            for hvo in resp.response.header_mutation.set_headers
+        }
+        assert set_headers[":authority"] == "api.groq.com"
+        assert set_headers[":path"] == "/openai/v1/chat/completions"
+        assert set_headers["authorization"] == "Bearer gsk-test"
+        assert set_headers[HEADER_PORTKEY_PROVIDER] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_on_request_body_openrouter_preserves_inner_slash_in_model(svc):
+    with respx.mock(
+        base_url="http://127.0.0.1:1",
+        assert_all_mocked=False,
+        assert_all_called=False,
+    ) as mock_router:
+        mock_router.route(
+            host="127.0.0.1", port=svc._capture.request_port
+        ).pass_through()
+
+        capture_port = svc._capture.request_port
+
+        async def fake_portkey(request: httpx.Request) -> httpx.Response:
+            corr = request.headers["x-portkey-callout-correlation"]
+            assert request.headers["authorization"] == "Bearer or-test"
+            # Body Portkey received should have the openrouter prefix stripped,
+            # but the inner provider/model preserved.
+            body = json.loads(request.content)
+            assert body["model"] == "openai/gpt-oss-20b:free"
+            async with httpx.AsyncClient() as c:
+                # Real Portkey strips OpenRouter's "/api" URL prefix when
+                # forwarding to custom_host; the callout reattaches it via
+                # api_path_prefix.
+                await c.post(
+                    f"http://127.0.0.1:{capture_port}/v1/chat/completions",
+                    content=(b'{"model":"openai/gpt-oss-20b:free","messages":'
+                             b'[{"role":"user","content":"hi"}]}'),
+                    headers={
+                        "authorization": "Bearer or-test",
+                        "x-portkey-callout-correlation": corr,
+                    },
+                )
+            return httpx.Response(200, json={})
+
+        mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
+
+        ctx = _Ctx()
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions"}), ctx)
+        req = json.dumps({
+            "model": "openrouter/openai/gpt-oss-20b:free",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+
+        assert isinstance(resp, service_pb2.BodyResponse)
+        set_headers = {
+            hvo.header.key: hvo.header.raw_value.decode()
+            for hvo in resp.response.header_mutation.set_headers
+        }
+        assert set_headers[":authority"] == "openrouter.ai"
+        assert set_headers[":path"] == "/api/v1/chat/completions"
+        assert set_headers["authorization"] == "Bearer or-test"
+        assert set_headers[HEADER_PORTKEY_PROVIDER] == "openrouter"

--- a/callouts/python/extproc/tests/portkey_gateway_test.py
+++ b/callouts/python/extproc/tests/portkey_gateway_test.py
@@ -295,7 +295,7 @@ async def test_translate_includes_extra_headers_in_forward_list():
 
 @pytest.fixture(scope="module")
 def svc():
-    """Callout instance: no gRPC server, no GCP creds, no Portkey sidecar."""
+    """Callout instance with no server started and no real GCP credentials."""
     with patch.dict(os.environ, {
         "GCP_PROJECT_ID": "test-project",
         "GCP_REGION": "us-central1",
@@ -312,8 +312,13 @@ def svc():
         callout = PortkeyGatewayCallout(
             disable_tls=True,
             combined_health_check=True,
+            plaintext_address=("0.0.0.0", 0),
         )
-        yield callout
+        try:
+            yield callout
+        finally:
+            if callout._callout_server is not None:
+                callout._callout_server.stop()
 
 
 def _http_headers(d: dict) -> service_pb2.HttpHeaders:

--- a/callouts/python/extproc/tests/portkey_gateway_test.py
+++ b/callouts/python/extproc/tests/portkey_gateway_test.py
@@ -20,9 +20,11 @@ proto objects or simple inputs; HTTP interactions with the Portkey sidecar
 are mocked via ``respx``.
 """
 
+import asyncio
 import gzip
 import json
 import os
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -39,8 +41,7 @@ from envoy.type.v3.http_status_pb2 import StatusCode
 
 from extproc.example.portkey_gateway import service_callout_example as sce
 from extproc.example.portkey_gateway.capture_server import (
-    REQUEST_CAPTURE_PROVIDERS,
-    build_stub_response,
+    CORRELATION_HEADER,
     CaptureServer,
 )
 from extproc.example.portkey_gateway.portkey_client import PortkeyClient
@@ -113,114 +114,103 @@ def test_mint_adc_token_refreshes_when_invalid():
         assert fake_creds.refresh.called
 
 
-def test_build_stub_response_anthropic_minimum_fields():
-    body = build_stub_response("anthropic")
-    parsed = json.loads(body)
-    # Anthropic response shape: id/type/role/content/model/usage.
-    assert parsed["type"] == "message"
-    assert parsed["role"] == "assistant"
-    assert isinstance(parsed["content"], list)
-    assert parsed["content"] and parsed["content"][0]["type"] == "text"
-    assert "usage" in parsed
-
-
-def test_build_stub_response_vertex_minimum_fields():
-    body = build_stub_response("vertex_ai")
-    parsed = json.loads(body)
-    # Vertex generateContent shape.
-    assert "candidates" in parsed and parsed["candidates"]
-    assert parsed["candidates"][0]["content"]["role"] == "model"
-
-
-def test_build_stub_response_groq_returns_openai_chat_shape():
-    body = build_stub_response("groq")
-    parsed = json.loads(body)
-    assert parsed["object"] == "chat.completion"
-    assert parsed["choices"][0]["message"]["role"] == "assistant"
-
-
-def test_build_stub_response_openrouter_returns_openai_chat_shape():
-    body = build_stub_response("openrouter")
-    parsed = json.loads(body)
-    assert parsed["object"] == "chat.completion"
-    assert parsed["choices"][0]["message"]["role"] == "assistant"
-
-
-def test_request_capture_providers_match_callout_registry():
-    # Every provider the callout can route must have a stub response shape,
-    # or the request-capture loopback breaks when that provider is used.
-    assert set(REQUEST_CAPTURE_PROVIDERS) == set(PROVIDERS)
-
-
-def test_disarm_clears_pending_correlation_state():
-    server = CaptureServer(request_port=0, response_port=0)
-    server.arm_request("corr-1", provider="anthropic")
-    server.arm_response("corr-1", b"provider bytes")
-    server.disarm("corr-1")
-    assert server._armed_request == {}
-    assert server._armed_response == {}
-    # Disarming an unknown correlation is a no-op, not an error.
-    server.disarm("corr-never-armed")
-
-
 @pytest.mark.asyncio
-async def test_request_capture_stores_body_and_returns_stub():
-    server = CaptureServer(request_port=0, response_port=0)
+async def test_capture_parks_connection_until_response_is_provided():
+    """The core of the loopback: Portkey's request is captured immediately,
+    but its connection stays open until the provider's real response is
+    supplied, so Portkey sees one request/response exchange."""
+    server = CaptureServer(port=0)
     await server.start()
+    provider_response = (
+        b'{"id":"msg_real","content":[{"type":"text","text":"hello"}]}')
     try:
-        # Pre-arm: tell the server which provider this correlation id targets.
-        server.arm_request("corr-1", provider="anthropic")
+        await server.arm("corr-1")
 
-        url = f"http://127.0.0.1:{server.request_port}/v1/messages"
         async with ClientSession() as s:
-            r = await s.post(
-                url,
+            post = asyncio.create_task(s.post(
+                f"http://127.0.0.1:{server.port}/v1/messages",
                 data=b'{"model":"claude-3","messages":[]}',
                 headers={
                     "x-api-key": "sk-ant-xxx",
                     "anthropic-version": "2023-06-01",
-                    "x-portkey-callout-correlation": "corr-1",
+                    CORRELATION_HEADER: "corr-1",
                 },
-            )
-            stub_body = await r.read()
+            ))
 
-        captured = server.take_captured_request("corr-1")
-        assert captured.body == b'{"model":"claude-3","messages":[]}'
-        assert captured.path == "/v1/messages"
-        assert captured.headers["x-api-key"] == "sk-ant-xxx"
-        # Stub response is Anthropic-shaped.
-        assert b'"type": "message"' in stub_body
+            # The translated request is readable as soon as it is captured.
+            captured = await server.wait_for_capture("corr-1", timeout=5)
+            assert captured.body == b'{"model":"claude-3","messages":[]}'
+            assert captured.path == "/v1/messages"
+            assert captured.headers["x-api-key"] == "sk-ant-xxx"
+
+            # The connection is parked: no response has been written yet.
+            assert not post.done()
+
+            # Unparking returns the provider's real bytes (no stub involved).
+            await server.provide_response("corr-1", provider_response)
+            r = await asyncio.wait_for(post, timeout=5)
+            assert r.status == 200
+            assert await r.read() == provider_response
+
+        assert server._pending == {}
     finally:
         await server.stop()
 
 
 @pytest.mark.asyncio
-async def test_response_replay_returns_armed_bytes():
-    server = CaptureServer(request_port=0, response_port=0)
+async def test_disarm_releases_parked_connection():
+    """Abandoning a stream must not leave the connection parked until the
+    park timeout expires."""
+    server = CaptureServer(port=0)
     await server.start()
-    armed = b'{"id":"msg_real","content":[{"type":"text","text":"hello"}]}'
     try:
-        server.arm_response("corr-2", armed)
+        await server.arm("corr-2")
+        async with ClientSession() as s:
+            post = asyncio.create_task(s.post(
+                f"http://127.0.0.1:{server.port}/v1/messages",
+                data=b"{}",
+                headers={CORRELATION_HEADER: "corr-2"},
+            ))
+            await server.wait_for_capture("corr-2", timeout=5)
+            await server.disarm("corr-2")
+            r = await asyncio.wait_for(post, timeout=5)
+            assert r.status == 502
+
+        assert server._pending == {}
+        # Disarming an unknown correlation is a no-op, not an error.
+        await server.disarm("corr-never-armed")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_park_timeout_returns_504_and_cleans_up():
+    """A stream abandoned after the request phase (no provider response
+    ever supplied) must not hold the parked connection forever."""
+    server = CaptureServer(port=0, park_timeout=0.3)
+    await server.start()
+    try:
+        await server.arm("corr-to")
         async with ClientSession() as s:
             r = await s.post(
-                f"http://127.0.0.1:{server.response_port}/v1/messages",
-                data=b'{"model":"claude-3","messages":[]}',
-                headers={"x-portkey-callout-correlation": "corr-2"},
+                f"http://127.0.0.1:{server.port}/v1/messages",
+                data=b"{}",
+                headers={CORRELATION_HEADER: "corr-to"},
             )
-            body = await r.read()
-        assert body == armed
+            assert r.status == 504
+        assert "corr-to" not in server._pending
     finally:
         await server.stop()
 
 
 @pytest.mark.asyncio
 async def test_capture_rejects_missing_correlation_header():
-    server = CaptureServer(request_port=0, response_port=0)
+    server = CaptureServer(port=0)
     await server.start()
     try:
         async with ClientSession() as s:
             r = await s.post(
-                f"http://127.0.0.1:{server.request_port}/anything",
+                f"http://127.0.0.1:{server.port}/anything",
                 data=b"",
             )
             assert r.status == 400
@@ -304,10 +294,9 @@ def svc():
         "OPENROUTER_API_KEY": "or-test",
         # Point at a port nothing is listening on; respx mocks the actual call.
         "PORTKEY_BASE_URL": "http://127.0.0.1:1",
-        # Use OS-picked ephemeral ports so test runs never collide with each
-        # other or with a real capture server.
-        "CAPTURE_REQUEST_PORT": "0",
-        "CAPTURE_RESPONSE_PORT": "0",
+        # Use an OS-picked ephemeral port so test runs never collide with
+        # each other or with a real capture server.
+        "CAPTURE_PORT": "0",
     }):
         callout = PortkeyGatewayCallout(
             disable_tls=True,
@@ -319,6 +308,24 @@ def svc():
         finally:
             if callout._callout_server is not None:
                 callout._callout_server.stop()
+
+
+def _release(svc, ctx) -> None:
+    """Release the Portkey call a request-phase test leaves parked.
+
+    In the real flow the response phase unparks the connection. Tests that
+    stop after the request phase must do it explicitly, or the capture
+    server holds the connection until its park timeout.
+    """
+    state = _state(ctx)
+    if state.portkey_call is None:
+        return
+    svc._run_async(svc._capture.disarm(state.correlation))
+    try:
+        state.portkey_call.result(timeout=5)
+    except Exception:
+        pass
+    state.portkey_call = None
 
 
 def _http_headers(d: dict) -> service_pb2.HttpHeaders:
@@ -397,7 +404,7 @@ async def test_on_request_body_anthropic_drives_capture_and_rewrites(svc):
             # The callout's `api_path_prefix` reattaches `/v1` before the LB
             # forwards to api.anthropic.com.
             await c.post(
-                f"http://127.0.0.1:{svc._capture.request_port}/messages",
+                f"http://127.0.0.1:{svc._capture.port}/messages",
                 content=(b'{"model":"claude-3-5-sonnet","max_tokens":32,'
                          b'"messages":[{"role":"user","content":"hi"}]}'),
                 headers={
@@ -420,7 +427,7 @@ async def test_on_request_body_anthropic_drives_capture_and_rewrites(svc):
         mock_router.post("http://127.0.0.1:1/v1/chat/completions").mock(
             side_effect=fake_portkey)
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.request_port).pass_through()
+            host="127.0.0.1", port=svc._capture.port).pass_through()
 
         ctx = _Ctx()
         svc.on_request_headers(
@@ -431,6 +438,7 @@ async def test_on_request_body_anthropic_drives_capture_and_rewrites(svc):
             "messages": [{"role": "user", "content": "hi"}],
         }).encode())
         resp = svc.on_request_body(body, ctx)
+        _release(svc, ctx)
 
     assert isinstance(resp, service_pb2.BodyResponse)
     new_body = resp.response.body_mutation.body
@@ -477,8 +485,7 @@ def test_on_request_body_portkey_failure_disarms_capture(svc, monkeypatch):
     assert resp.status.code == StatusCode.BadGateway
     # The failed correlation must not linger in the capture server.
     corr = _state(ctx).correlation
-    assert corr not in svc._capture._armed_request
-    assert corr not in svc._capture._captured
+    assert corr not in svc._capture._pending
 
 
 def test_on_request_body_anthropic_defaults_max_tokens(svc, monkeypatch):
@@ -517,6 +524,31 @@ def test_on_request_body_anthropic_defaults_max_tokens(svc, monkeypatch):
     assert captured["openai_body"]["max_tokens"] == 32
 
 
+def test_on_request_body_fast_fails_when_portkey_never_posts(
+        svc, monkeypatch):
+    """If Portkey answers with its own error response instead of POSTing to
+    the capture server, the callout must fail promptly rather than sitting
+    out the full capture timeout."""
+    async def error_without_post(**kwargs):
+        return httpx.Response(424, text="unsupported provider config")
+
+    monkeypatch.setattr(svc._client, "translate", error_without_post)
+    ctx = _Ctx()
+    svc.on_request_headers(
+        _http_headers({":path": "/v1/chat/completions"}), ctx)
+    body = service_pb2.HttpBody(body=json.dumps({
+        "model": "anthropic/claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode())
+    start = time.monotonic()
+    resp = svc.on_request_body(body, ctx)
+    elapsed = time.monotonic() - start
+    assert resp.status.code == StatusCode.BadGateway
+    # The fast path, not the 30s capture timeout.
+    assert elapsed < 10
+    assert _state(ctx).correlation not in svc._capture._pending
+
+
 def test_on_request_body_invalid_json_returns_400(svc):
     ctx = _Ctx()
     svc.on_request_headers(
@@ -548,9 +580,10 @@ def test_on_request_body_unknown_provider_returns_400(svc):
 
 
 @pytest.mark.asyncio
-async def test_on_response_body_translates_anthropic_to_openai(svc):
-    """Response phase: callout has captured request state, gets Anthropic-format
-    response from LB, replays through Portkey, returns OpenAI body."""
+async def test_full_cycle_translates_anthropic_response_to_openai(svc):
+    """One Portkey call spans both phases: the callout reads the translated
+    request off the parked connection, later writes the provider's response
+    onto that same connection, and the call resolves with OpenAI format."""
     with respx.mock(
         base_url="http://127.0.0.1:1",
         assert_all_mocked=False,
@@ -558,24 +591,29 @@ async def test_on_response_body_translates_anthropic_to_openai(svc):
     ) as mock_router:
         # Let the inner httpx.AsyncClient hit the real localhost capture server.
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.response_port
+            host="127.0.0.1", port=svc._capture.port
         ).pass_through()
 
-        replay_port = svc._capture.response_port
+        capture_port = svc._capture.port
 
         async def fake_portkey(request: httpx.Request) -> httpx.Response:
-            corr = request.headers["x-portkey-callout-correlation"]
-            # Simulate Portkey: POST to :9998 and let it stream the captured
-            # provider response back; here we just verify the replay happens.
-            async with httpx.AsyncClient() as c:
+            corr = request.headers[CORRELATION_HEADER]
+            # Portkey POSTs the translated request, then blocks on the parked
+            # connection until the callout supplies the provider's response.
+            async with httpx.AsyncClient(
+                    transport=httpx.AsyncHTTPTransport()) as c:
                 r = await c.post(
-                    f"http://127.0.0.1:{replay_port}/v1/messages",
-                    content=b"",
-                    headers={"x-portkey-callout-correlation": corr},
+                    f"http://127.0.0.1:{capture_port}/messages",
+                    content=(b'{"model":"claude-3-5-sonnet","max_tokens":32,'
+                             b'"messages":[{"role":"user","content":"hi"}]}'),
+                    headers={
+                        "x-api-key": "sk-ant-test",
+                        CORRELATION_HEADER: corr,
+                    },
+                    timeout=30,
                 )
                 provider_body = await r.aread()
-            # In reality Portkey parses provider_body and emits OpenAI; we
-            # synthesize one for the test.
+            # Portkey now translates the provider response it just received.
             assert b'"msg_real"' in provider_body
             return httpx.Response(200, json={
                 "id": "chatcmpl-fake",
@@ -589,13 +627,16 @@ async def test_on_response_body_translates_anthropic_to_openai(svc):
 
         mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
 
-        # Arrange callout state as if the request phase had run successfully.
         ctx = _Ctx()
-        state = _state(ctx)
-        state.is_llm = True
-        state.provider = "anthropic"
-        state.correlation = "corr-rsp-1"
-        state.request_body = {"model": "claude-3-5-sonnet", "messages": []}
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions"}), ctx)
+        req = json.dumps({
+            "model": "anthropic/claude-3-5-sonnet",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        req_resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+        assert isinstance(req_resp, service_pb2.BodyResponse)
 
         anthropic_response = (
             b'{"id":"msg_real","type":"message",'
@@ -609,6 +650,8 @@ async def test_on_response_body_translates_anthropic_to_openai(svc):
         new_body = json.loads(resp.response.body_mutation.body)
         assert new_body["object"] == "chat.completion"
         assert new_body["choices"][0]["message"]["content"] == "hi back"
+        # The parked connection is resolved and its state cleaned up.
+        assert _state(ctx).correlation not in svc._capture._pending
 
 
 @pytest.mark.asyncio
@@ -622,23 +665,26 @@ async def test_on_response_body_reassembles_chunked_gzip_response(svc):
         assert_all_called=False,
     ) as mock_router:
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.response_port
+            host="127.0.0.1", port=svc._capture.port
         ).pass_through()
 
-        replay_port = svc._capture.response_port
+        capture_port = svc._capture.port
 
         async def fake_portkey(request: httpx.Request) -> httpx.Response:
-            corr = request.headers["x-portkey-callout-correlation"]
-            async with httpx.AsyncClient() as c:
+            corr = request.headers[CORRELATION_HEADER]
+            async with httpx.AsyncClient(
+                    transport=httpx.AsyncHTTPTransport()) as c:
                 r = await c.post(
-                    f"http://127.0.0.1:{replay_port}/v1/chat/completions",
-                    content=b"",
-                    headers={"x-portkey-callout-correlation": corr},
+                    f"http://127.0.0.1:{capture_port}/v1/chat/completions",
+                    content=(b'{"model":"openai/gpt-oss-20b:free",'
+                             b'"messages":[{"role":"user","content":"hi"}]}'),
+                    headers={CORRELATION_HEADER: corr},
+                    timeout=30,
                 )
                 provider_body = await r.aread()
-            # The replayed body must be the gunzipped, reassembled JSON.
-            replayed = json.loads(provider_body)
-            assert replayed["id"] == "gen-or-1"
+            # The unparked body must be the gunzipped, reassembled JSON.
+            unparked = json.loads(provider_body)
+            assert unparked["id"] == "gen-or-1"
             return httpx.Response(200, json={
                 "id": "chatcmpl-or",
                 "object": "chat.completion",
@@ -652,12 +698,15 @@ async def test_on_response_body_reassembles_chunked_gzip_response(svc):
         mock_router.post("/v1/chat/completions").mock(side_effect=fake_portkey)
 
         ctx = _Ctx()
-        state = _state(ctx)
-        state.is_llm = True
-        state.provider = "openrouter"
-        state.correlation = "corr-or-1"
-        state.request_body = {"model": "openai/gpt-oss-20b:free",
-                              "messages": []}
+        svc.on_request_headers(
+            _http_headers({":path": "/v1/chat/completions"}), ctx)
+        req = json.dumps({
+            "model": "openrouter/openai/gpt-oss-20b:free",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        assert isinstance(
+            svc.on_request_body(service_pb2.HttpBody(body=req), ctx),
+            service_pb2.BodyResponse)
 
         compressed = gzip.compress(
             b'{"id":"gen-or-1","object":"chat.completion","choices":[]}')
@@ -728,10 +777,10 @@ async def test_on_request_body_vertex_uses_adc_token_and_region(svc):
         assert_all_called=False,
     ) as mock_router:
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.request_port
+            host="127.0.0.1", port=svc._capture.port
         ).pass_through()
 
-        capture_port = svc._capture.request_port
+        capture_port = svc._capture.port
         # Vertex AI is the no-prefix provider: Portkey emits the full
         # generateContent path, so the callout forwards it verbatim.
         vertex_path = (
@@ -775,6 +824,7 @@ async def test_on_request_body_vertex_uses_adc_token_and_region(svc):
                 "messages": [{"role": "user", "content": "hi"}],
             }).encode()
             resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+            _release(svc, ctx)
 
         assert isinstance(resp, service_pb2.BodyResponse)
         set_headers = {
@@ -799,10 +849,10 @@ async def test_on_request_body_groq_uses_api_key_env(svc):
         assert_all_called=False,
     ) as mock_router:
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.request_port
+            host="127.0.0.1", port=svc._capture.port
         ).pass_through()
 
-        capture_port = svc._capture.request_port
+        capture_port = svc._capture.port
 
         async def fake_portkey(request: httpx.Request) -> httpx.Response:
             corr = request.headers["x-portkey-callout-correlation"]
@@ -832,6 +882,7 @@ async def test_on_request_body_groq_uses_api_key_env(svc):
             "messages": [{"role": "user", "content": "hi"}],
         }).encode()
         resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+        _release(svc, ctx)
 
         assert isinstance(resp, service_pb2.BodyResponse)
         set_headers = {
@@ -852,10 +903,10 @@ async def test_on_request_body_openrouter_preserves_inner_slash_in_model(svc):
         assert_all_called=False,
     ) as mock_router:
         mock_router.route(
-            host="127.0.0.1", port=svc._capture.request_port
+            host="127.0.0.1", port=svc._capture.port
         ).pass_through()
 
-        capture_port = svc._capture.request_port
+        capture_port = svc._capture.port
 
         async def fake_portkey(request: httpx.Request) -> httpx.Response:
             corr = request.headers["x-portkey-callout-correlation"]
@@ -889,6 +940,7 @@ async def test_on_request_body_openrouter_preserves_inner_slash_in_model(svc):
             "messages": [{"role": "user", "content": "hi"}],
         }).encode()
         resp = svc.on_request_body(service_pb2.HttpBody(body=req), ctx)
+        _release(svc, ctx)
 
         assert isinstance(resp, service_pb2.BodyResponse)
         set_headers = {

--- a/callouts/python/requirements-test.txt
+++ b/callouts/python/requirements-test.txt
@@ -4,3 +4,5 @@ pyjwt[crypto]==2.13.0
 litellm==1.83.0
 httpx>=0.27,<1.0
 google-cloud-aiplatform>=1.50.0
+pytest-asyncio>=0.24,<2.0
+respx>=0.20,<1.0


### PR DESCRIPTION
Adds a Portkey Gateway Python sample, a Service Extensions ext_proc callout that turns a Google Cloud external Application Load Balancer into an OpenAI-compatible multi-provider gateway.                                        
                                                                                                                                                                                                                                    
The LB routes each request to the right provider backend (Vertex AI, Anthropic, Groq, OpenRouter) via Internet NEGs; the callout fronts a self-hosted Portkey AI gateway running as a sidecar container in the same Cloud Run service to translate OpenAI <-> provider formats and inject the right auth (ADC for Vertex AI; Secret Manager-backed API keys for the others). Rather than letting Portkey call the provider, the callout uses Portkey's custom_host feature to intercept the translated bytes on a loopback port; the LB owns the outbound connection.                                                                                                                                
                                                                                                                                                                                                                                    
The callout doesn't proxy traffic, it only mutates the body and headers, and the LB forwards straight to the provider. Routing is header-driven (x-model-id, the full model id, with the URL map matching on the provider prefix)