### PR TITLE
feat: Updating attributes naming for Geo Direction Origin rust plugin

### DIFF
--- a/plugins/samples/geo_directional_origin/README.md
+++ b/plugins/samples/geo_directional_origin/README.md
@@ -6,7 +6,7 @@ This plugin reads the client's geographic region from the proxy's request metada
 
 1. The proxy receives an HTTP request from a client and invokes the plugin's `on_http_request_headers` callback.
 
-2. The plugin reads the `request.client_region` property from the proxy's request metadata using `proxywasm.GetProperty()`. This property is populated by the proxy based on the client's IP address using GeoIP lookup.
+2. The plugin reads the `source.client_region` property from the proxy's request metadata using `self.get_property()`. This property is populated by the proxy based on the client's IP address using GeoIP lookup. (The property path follows the Google Cloud Service Extensions [supported attributes](https://cloud.google.com/service-extensions/docs/attributes?hl=pt-br) documentation.)
 
 3. **If a country code is available** (non-empty):
    - The plugin sets the `x-country-code` header to the country code value (e.g., `"US"`, `"DE"`, `"JP"`, `"BR"`).
@@ -19,28 +19,57 @@ This plugin reads the client's geographic region from the proxy's request metada
 
 6. The plugin returns `types.ActionContinue`, forwarding the modified request to the upstream server.
 
+## How to Use the Injected Header for Geo‑Routing
+
+The plugin **only injects the header** – it does **not** perform routing itself. To use the country code for routing decisions, you must configure your load balancer or Envoy proxy to read the `x-country-code` header and forward traffic to the appropriate backend.
+
+For example, on a Google Cloud Application Load Balancer, you can use a URL map with `headerMatcher` rules:
+
+```yaml
+routeRules:
+  - priority: 1
+    matchRules:
+      - prefixMatch: "/"
+        headerMatches:
+          - headerName: "x-country-code"
+            exactMatch: "US"
+    service: "backend-us"
+  - priority: 2
+    matchRules:
+      - prefixMatch: "/"
+        headerMatches:
+          - headerName: "x-country-code"
+            exactMatch: "FR"
+    service: "backend-eu"
+  # default fallback
+
 ## Implementation Notes
 
-- **Metadata retrieval**: Reads the client's country code dynamically assigned by proxy metadata via `proxywasm.GetProperty()`.
+- **Metadata retrieval**: Reads the client's country code dynamically assigned by proxy metadata via `self.get_property()` using the official `source.client_region` attribute.
 - **Authoritative routing header**: Replaces any existing `x-country-code` header to prevent spoofed client origins.
 - **Spoofing mitigation**: Completely removes the header if valid proxy geo-metadata cannot be retrieved.
 
 ## Configuration
 
-No configuration required. The property path (`request.client_region`) and header name (`x-country-code`) are hardcoded in the plugin source.
+No configuration required. The property path (`source.client_region`) and header name (`x-country-code`) are in the plugin source.
 
-**Property source**: The `request.client_region` property is populated by the proxy (e.g., Envoy, Google Cloud Service Extensions) based on GeoIP lookup of the client's source IP address. The property must be made available by the proxy environment for this plugin to function correctly.
+Property source: The `source.client_region` property is populated by the proxy (e.g., Envoy, Google Cloud Service Extensions) based on GeoIP lookup of the client's source IP address. The property must be made available by the proxy environment for this plugin to function correctly.
+
+Important for Google Cloud Service Extensions: To receive the `source.client_region` property, you must explicitly list it in the `forwardAttributes` field of your extension configuration. Example:
+
+extension_chains:
+  extensions:
+    forward_attributes:
+      - source.client_region
 
 ## Build
 
-Build the plugin for Go from the `plugins/` directory:
+Build the plugin for from the `plugins/` directory:
 
 ```bash
 # Go
-bazelisk build //samples/geo_routing:plugin_go.wasm
+bazelisk build //samples/geo_directional_origin:plugin_rust.wasm
 ```
-
-**Note**: Only Go implementation is available for this plugin.
 
 ## Test
 
@@ -50,11 +79,11 @@ Run the unit tests defined in `tests.textpb`:
 # Using Docker (recommended)
 docker run -it -v $(pwd):/mnt \
     us-docker.pkg.dev/service-extensions-samples/plugins/wasm-tester:main \
-    --proto /mnt/samples/geo_routing/tests.textpb \
-    --plugin /mnt/bazel-bin/samples/geo_routing/plugin_go.wasm
+    --proto /mnt/samples/geo_directional_origin/tests.textpb \
+    --plugin /mnt/bazel-bin/samples/geo_directional_origin/plugin_go.wasm
 
 # Using Bazel
-bazelisk test --test_output=all //samples/geo_routing:tests
+bazelisk test --test_output=all //samples/geo_directional_origin:tests
 ```
 
 ## Expected Behavior
@@ -75,6 +104,6 @@ Derived from [`tests.textpb`](tests.textpb):
 
 ## Available Languages
 
-- [ ] Rust (not available)
+- [x] Rust (plugin.rs)
 - [ ] C++ (not available)
-- [x] [Go](plugin.go)
+- [ ] Go (not available)

--- a/plugins/samples/geo_directional_origin/plugin.rs
+++ b/plugins/samples/geo_directional_origin/plugin.rs
@@ -16,33 +16,38 @@
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::{Action, LogLevel};
 
-const CLIENT_REGION_PROPERTY: &[&str] = &["request", "client_region"];
+const CLIENT_REGION_PROPERTY: &[&str] = &["source", "client_region"];
 const COUNTRY_CODE_HEADER: &str = "x-country-code";
 
 proxy_wasm::main! {{
     proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> {
-        Box::new(GeoRoutingContext)
+        Box::new(MyHttpContext)
     });
 }}
 
-struct GeoRoutingContext;
+struct MyHttpContext;
 
-impl Context for GeoRoutingContext {}
+impl Context for MyHttpContext {}
 
-impl HttpContext for GeoRoutingContext {
-    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
-        if let Some(country_bytes) = self.get_property(CLIENT_REGION_PROPERTY.to_vec()) {
-            if let Ok(country_code) = std::str::from_utf8(&country_bytes) {
-                if !country_code.is_empty() {
-                    self.set_http_request_header(COUNTRY_CODE_HEADER, Some(country_code));
-                    return Action::Continue;
+impl MyHttpContext {
+    #[inline]
+    fn set_geo_header(&mut self, property: &[&str], header: &str) {
+        if let Some(bytes) = self.get_property(property.to_vec()) {
+            if let Ok(value) = std::str::from_utf8(&bytes) {
+                if !value.is_empty() {
+                    self.set_http_request_header(header, Some(value));
+                    return;
                 }
             }
         }
+        self.set_http_request_header(header, None);
+    }
+}
 
-        self.set_http_request_header(COUNTRY_CODE_HEADER, None);
-
+impl HttpContext for MyHttpContext {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        self.set_geo_header(CLIENT_REGION_PROPERTY, COUNTRY_CODE_HEADER);
         Action::Continue
     }
 }

--- a/plugins/samples/geo_directional_origin/tests.textpb
+++ b/plugins/samples/geo_directional_origin/tests.textpb
@@ -1,8 +1,12 @@
+# Copyright 2026 Google LLC
+# Licensed under the Apache License, Version 2.0
+
+# Test: Inject x-country-code header when client region is US.
 test {
   name: "SetHeaderForUS"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "US"
   }
   request_headers {
@@ -17,11 +21,12 @@ test {
   }
 }
 
+# Test: Inject x-country-code header when client region is Germany (DE).
 test {
   name: "SetHeaderForGermany"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "DE"
   }
   request_headers {
@@ -36,11 +41,12 @@ test {
   }
 }
 
+# Test: Inject x-country-code header when client region is Japan (JP).
 test {
   name: "SetHeaderForJapan"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "JP"
   }
   request_headers {
@@ -55,11 +61,12 @@ test {
   }
 }
 
+# Test: Inject x-country-code header when client region is Brazil (BR).
 test {
   name: "SetHeaderForBrazil"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "BR"
   }
   request_headers {
@@ -74,6 +81,7 @@ test {
   }
 }
 
+# Test: No geo information available → header should not be added.
 test {
   name: "NoGeoInformationAvailable"
   benchmark: false
@@ -89,11 +97,12 @@ test {
   }
 }
 
+# Test: Empty country code, header should be removed (not set).
 test {
   name: "EmptyCountryCode"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: ""
   }
   request_headers {
@@ -108,11 +117,12 @@ test {
   }
 }
 
+# Test: Inject x-country-code header when client region is South Africa (ZA).
 test {
   name: "SetHeaderForSouthAfrica"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "ZA"
   }
   request_headers {
@@ -127,11 +137,12 @@ test {
   }
 }
 
+# Test: Spoofed x-country-code header should be removed and replaced with the correct value.
 test {
   name: "SecuritySpoofedHeaderRemoved"
   benchmark: false
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "GB"
   }
   request_headers {
@@ -147,11 +158,12 @@ test {
   }
 }
 
+# Test: Benchmark test.
 test {
   name: "BenchmarkGeoRouting"
   benchmark: true
   properties {
-    path: "request.client_region"
+    path: "source.client_region"
     value: "GB"
   }
   request_headers {


### PR DESCRIPTION
This PR updates the Geo Routing plugin to use the correct attribute for client region retrieval. According to the official Google Cloud Service Extensions [documentation](https://cloud.google.com/service-extensions/docs/attributes), the property `source.client_region` should be used instead of the previously used `request.client_region`.

Also updating the tests and the README.md file to reflect these changes.