### PR TITLE
refactor(lua): use pragma once for header guards, rename namespace to proxy_wasm_lua

### DIFF
--- a/plugins/samples/lua/coroutine.cc
+++ b/plugins/samples/lua/coroutine.cc
@@ -35,7 +35,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 absl::StatusOr<ExecutionState> LuaStreamCoroutine::Start() {
   if (state_ != ExecutionState::kYielded ||
@@ -284,4 +284,4 @@ absl::StatusOr<ExecutionState> LuaStreamCoroutine::HandleHttpResponse(
   return state_;
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/coroutine.h
+++ b/plugins/samples/lua/coroutine.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_COROUTINE_H_
-#define NET_TURING_WASM_LUA_COROUTINE_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -29,7 +28,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 enum class LuaStreamCoroutineMode { kRequest, kResponse };
 
@@ -124,5 +123,4 @@ class LuaStreamCoroutine final : public StreamStateInterface {
   bool stream_ended_ = false;
 };
 
-}  // namespace sample::lua
-#endif  // NET_TURING_WASM_LUA_COROUTINE_H_
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/coroutine_test.cc
+++ b/plugins/samples/lua/coroutine_test.cc
@@ -54,7 +54,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 namespace {
 
 using ::testing::_;
@@ -1149,4 +1149,4 @@ TEST(LuaStreamCoroutineTest,
   { auto _s = coroutine.Start(); EXPECT_TRUE(GetStatus(_s).ok()); EXPECT_THAT(*_s, ExecutionState::kExited); };
 }
 }  // namespace
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/envoy_lua_api.cc
+++ b/plugins/samples/lua/envoy_lua_api.cc
@@ -38,7 +38,7 @@
 #include "absl/time/time.h"
 #include "proxy_wasm_intrinsics.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 namespace {
 bool GetBoolValue(const std::initializer_list<std::string_view>& path) {
   bool out = false;
@@ -882,4 +882,4 @@ absl::StatusOr<StatsScope> Handle::GetStats() {
   return absl::UnimplementedError("unimplemented");
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/envoy_lua_api.h
+++ b/plugins/samples/lua/envoy_lua_api.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_ENVOY_LUA_API_H_
-#define NET_TURING_WASM_LUA_ENVOY_LUA_API_H_
+#pragma once
 
 // The C++ classes and Lua wrapper API surface defined in this file
 // (e.g., Handle, Header, StreamInfo) are designed to emulate Envoy's native
@@ -37,7 +36,7 @@
 #include "proxy_wasm_common.h"
 #include "proxy_wasm_enums.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 class Logger {
  public:
@@ -445,5 +444,4 @@ class Handle {
   bool is_request_;
 };
 
-}  // namespace sample::lua
-#endif  // NET_TURING_WASM_LUA_ENVOY_LUA_API_H_
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/envoy_lua_api_registration.cc
+++ b/plugins/samples/lua/envoy_lua_api_registration.cc
@@ -44,7 +44,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 namespace {
 
@@ -469,4 +469,4 @@ absl::Status RegisterEnvoyApi(LuaState& state) {
   return absl::OkStatus();
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/envoy_lua_api_registration.h
+++ b/plugins/samples/lua/envoy_lua_api_registration.h
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_ENVOY_LUA_API_REGISTRATION_H_
-#define NET_TURING_WASM_LUA_ENVOY_LUA_API_REGISTRATION_H_
+#pragma once
 
 #include "lua_state.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 // Helper to register absl::StatusOr<T> types with LuaBridge. The unwrapper uses
 // this to identify and extract the inner value of a StatusOr object.
@@ -28,6 +27,5 @@ void RegisterStatusOr(LuaState& state, absl::string_view name);
 
 absl::Status RegisterEnvoyApi(LuaState& state);
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua
 
-#endif  // NET_TURING_WASM_LUA_ENVOY_LUA_API_REGISTRATION_H_

--- a/plugins/samples/lua/envoy_lua_api_shims.h
+++ b/plugins/samples/lua/envoy_lua_api_shims.h
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_ENVOY_LUA_API_SHIMS_H_
-#define NET_TURING_WASM_LUA_ENVOY_LUA_API_SHIMS_H_
+#pragma once
 
 #include "absl/strings/string_view.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 constexpr absl::string_view kLua51CompatShims = R"lua(
   if table then
@@ -96,5 +95,4 @@ constexpr absl::string_view kStatusUnwrapperFunctionShim = R"lua(
   end
 )lua";
 
-}  // namespace sample::lua
-#endif  // NET_TURING_WASM_LUA_ENVOY_LUA_API_SHIMS_H_
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/envoy_lua_api_test.cc
+++ b/plugins/samples/lua/envoy_lua_api_test.cc
@@ -50,7 +50,7 @@ inline absl::Status GetStatus(const absl::Status& v) { return v; }
 #include "proxy_wasm_common.h"
 #include "proxy_wasm_enums.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 namespace {
 
 using ::testing::_;
@@ -1428,4 +1428,4 @@ TEST_F(HandleTest, GetHeadersMutationsBlockedWhenHeadersPassedOn) {
 }
 
 }  // namespace
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/lua_plugin.cc
+++ b/plugins/samples/lua/lua_plugin.cc
@@ -38,7 +38,7 @@ extern "C" {
 // not supported or needed in the Proxy-Wasm sandbox.
 int __syscall_dup3(int oldfd, int newfd, int flags) { return -ENOSYS; }
 }
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 namespace {
 
@@ -297,4 +297,4 @@ LuaState* LuaHttpContext::GetRootLuaState() {
   return lua_root->lua_state_.get();
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/lua_plugin.h
+++ b/plugins/samples/lua/lua_plugin.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_LUA_PLUGIN_H_
-#define NET_TURING_WASM_LUA_LUA_PLUGIN_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -31,7 +30,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 class LuaHttpContext final : public Context {
  public:
@@ -87,5 +86,4 @@ class LuaRootContext final : public RootContext {
   friend class LuaHttpContext;
 };
 
-}  // namespace sample::lua
-#endif  // NET_TURING_WASM_LUA_LUA_PLUGIN_H_
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/lua_plugin_registration.cc
+++ b/plugins/samples/lua/lua_plugin_registration.cc
@@ -14,9 +14,9 @@
 
 #include "lua_plugin.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 static RegisterContextFactory register_CustomContexts(
     CONTEXT_FACTORY(LuaHttpContext), ROOT_FACTORY(LuaRootContext), "");
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/lua_state.cc
+++ b/plugins/samples/lua/lua_state.cc
@@ -39,7 +39,7 @@ extern "C" {
 #include "absl/types/span.h"
 #include "LuaBridge/LuaBridge.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 namespace {
 
@@ -310,4 +310,4 @@ absl::StatusOr<ExecutionState> LuaState::Thread::ExecuteFunction(
   return ExecuteFunctionImpl(this, func_name, arg);
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/lua_state.h
+++ b/plugins/samples/lua/lua_state.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_LUA_STATE_H_
-#define NET_TURING_WASM_LUA_LUA_STATE_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -32,7 +31,7 @@ extern "C" {
 #include "lua.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 namespace internal {
 using LuaStatePtr =
@@ -161,6 +160,5 @@ class ScopedGlobalFunction {
   std::string name_;
 };
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua
 
-#endif  // NET_TURING_WASM_LUA_LUA_STATE_H_

--- a/plugins/samples/lua/lua_state_test.cc
+++ b/plugins/samples/lua/lua_state_test.cc
@@ -60,7 +60,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 namespace {
 
 using ::testing::HasSubstr;
@@ -590,9 +590,9 @@ TEST(LuaStateTest, ValidatesStatusIsCorrectlyInterceptedAndWrapped) {
           [](const absl::Status& s) { return std::string(s.message()); })
       .endClass();
 
-  sample::lua::RegisterStatusOr<std::string>(*state, "StatusOr_string");
-  sample::lua::RegisterStatusOr<int*>(*state, "StatusOr_int_ptr");
-  sample::lua::RegisterStatusOr<int>(*state, "StatusOr_int");
+  proxy_wasm_lua::RegisterStatusOr<std::string>(*state, "StatusOr_string");
+  proxy_wasm_lua::RegisterStatusOr<int*>(*state, "StatusOr_int_ptr");
+  proxy_wasm_lua::RegisterStatusOr<int>(*state, "StatusOr_int");
 
   luabridge::getGlobalNamespace(state->state())
       .beginClass<FakeStatusTest>("FakeStatusTest")
@@ -611,7 +611,7 @@ TEST(LuaStateTest, ValidatesStatusIsCorrectlyInterceptedAndWrapped) {
   (void)luabridge::push(state->state(), &fake_status);
   lua_setglobal(state->state(), "fake_status_object");
 
-  EXPECT_OK(state->ExecuteString(sample::lua::kStatusUnwrapperFunctionShim));
+  EXPECT_OK(state->ExecuteString(proxy_wasm_lua::kStatusUnwrapperFunctionShim));
 
   {
     ScopedGlobalFunction scoped_raw(
@@ -659,4 +659,4 @@ TEST(LuaStateTest, ValidatesStatusIsCorrectlyInterceptedAndWrapped) {
 }
 
 }  // namespace
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua

--- a/plugins/samples/lua/proxy_wasm_test_stubs.cc
+++ b/plugins/samples/lua/proxy_wasm_test_stubs.cc
@@ -21,14 +21,14 @@
 #include "proxy_wasm_intrinsics.h"
 
 namespace {
-sample::lua::MockProxyWasmAbi* absl_nullable current_mock_proxy_wasm_abi =
+proxy_wasm_lua::MockProxyWasmAbi* absl_nullable current_mock_proxy_wasm_abi =
     nullptr;
 }
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 MockProxyWasmAbi::MockProxyWasmAbi() { current_mock_proxy_wasm_abi = this; }
 MockProxyWasmAbi::~MockProxyWasmAbi() { current_mock_proxy_wasm_abi = nullptr; }
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua
 
 extern "C" {
 WasmResult proxy_log(LogLevel level, const char* logMessage,

--- a/plugins/samples/lua/proxy_wasm_test_stubs.h
+++ b/plugins/samples/lua/proxy_wasm_test_stubs.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_PROXY_WASM_TEST_STUBS_H_
-#define NET_TURING_WASM_LUA_PROXY_WASM_TEST_STUBS_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -26,7 +25,7 @@
 #include "absl/strings/match.h"
 #include "proxy_wasm_intrinsics.h"
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 class MockStreamState : public StreamStateInterface {
  public:
@@ -190,6 +189,5 @@ MATCHER_P(WasmHasSubstr, expected_substr, "") {
                            expected_substr);
 }
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua
 
-#endif  // NET_TURING_WASM_LUA_PROXY_WASM_TEST_STUBS_H_

--- a/plugins/samples/lua/status_macros.h
+++ b/plugins/samples/lua/status_macros.h
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LUA_STATUS_MACROS_H_
-#define LUA_STATUS_MACROS_H_
+#pragma once
 
 #define RETURN_IF_ERROR(expr) \
   do { \
     auto _status = (expr); \
     if (!_status.ok()) return _status; \
   } while (0)
-
-#endif  // LUA_STATUS_MACROS_H_

--- a/plugins/samples/lua/stream_state_interface.h
+++ b/plugins/samples/lua/stream_state_interface.h
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NET_TURING_WASM_LUA_STREAM_STATE_INTERFACE_H_
-#define NET_TURING_WASM_LUA_STREAM_STATE_INTERFACE_H_
+#pragma once
 
-namespace sample::lua {
+namespace proxy_wasm_lua {
 
 // Interface abstracting the coroutine functionality from the Lua stream
 // filtering layer.
@@ -46,6 +45,5 @@ class StreamStateInterface {
   [[nodiscard]] virtual bool IsStreamEnded() const = 0;
 };
 
-}  // namespace sample::lua
+}  // namespace proxy_wasm_lua
 
-#endif  // NET_TURING_WASM_LUA_STREAM_STATE_INTERFACE_H_


### PR DESCRIPTION
- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
